### PR TITLE
IOTEDGE-919 send Anvil debug to file

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -9,25 +9,23 @@
 package debug
 
 import (
-	"log"
 	"net/http"
 	"net/http/httputil"
 )
 
-// WriteRequest will dump the given request and response and prints the result to the configured writer
-func WriteRequest(logger *log.Logger, req *http.Request, res *http.Response) {
+// DumpRoundTrip will dump the given request and response
+func DumpRoundTrip(req *http.Request, res *http.Response) (message string) {
 	if req != nil {
 		dump, err := httputil.DumpRequest(req, true)
 		if err != nil {
 			dump, err = httputil.DumpRequest(req, false)
 		}
-		message := "*** HTTP Request ***\n"
+		message = "*** HTTP Request ***\n"
 		if err == nil {
 			message += string(dump)
 		} else {
 			message += "Failed to dump request: " + err.Error()
 		}
-		logger.Println(message)
 	}
 
 	if res != nil {
@@ -35,12 +33,12 @@ func WriteRequest(logger *log.Logger, req *http.Request, res *http.Response) {
 		if err != nil {
 			dump, err = httputil.DumpResponse(res, false)
 		}
-		message := "*** HTTP Response ***\n"
+		message += "*** HTTP Response ***\n"
 		if err == nil {
 			message += string(dump)
 		} else {
 			message += "Failed to dump response: " + err.Error()
 		}
-		logger.Println(message)
 	}
+	return message
 }

--- a/pkg/things/thing.go
+++ b/pkg/things/thing.go
@@ -22,13 +22,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ForgeRock/iot-edge/internal/debug"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/ForgeRock/iot-edge/internal/debug"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // All SDK debug information is written to this Logger. The logger is muted by default. To see the debug output assign
@@ -98,28 +99,28 @@ func (c AMClient) authenticate(_ context.Context, payload authenticatePayload) (
 	}
 	request, err := http.NewRequest(http.MethodPost, c.AuthURL, bytes.NewBuffer(requestBody))
 	if err != nil {
-		debug.WriteRequest(DebugLogger, request, nil)
+		DebugLogger.Println(debug.DumpRoundTrip(request, nil))
 		return reply, err
 	}
 	request.Header.Add(acceptAPIVersion, authNEndpointVersion)
 	request.Header.Add(contentType, applicationJson)
 	response, err := client.Do(request)
 	if err != nil {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return reply, err
 	}
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return reply, err
 	}
 	if response.StatusCode != http.StatusOK {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return reply, fmt.Errorf("authentication request failed")
 	}
 	if err = json.Unmarshal(responseBody, &reply); err != nil {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return reply, err
 	}
 	return reply, err
@@ -135,7 +136,7 @@ func (c AMClient) sendCommand(tokenID string, payload commandRequestPayload) (st
 	}
 	request, err := http.NewRequest(http.MethodPost, url, strings.NewReader(requestBody))
 	if err != nil {
-		debug.WriteRequest(DebugLogger, request, nil)
+		DebugLogger.Println(debug.DumpRoundTrip(request, nil))
 		return "", err
 	}
 	request.Header.Set(acceptAPIVersion, commandEndpointVersion)
@@ -143,17 +144,17 @@ func (c AMClient) sendCommand(tokenID string, payload commandRequestPayload) (st
 	request.AddCookie(&http.Cookie{Name: cookieName, Value: tokenID})
 	response, err := client.Do(request)
 	if err != nil {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return "", err
 	}
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return "", err
 	}
 	if response.StatusCode != http.StatusOK {
-		debug.WriteRequest(DebugLogger, request, response)
+		DebugLogger.Println(debug.DumpRoundTrip(request, response))
 		return "", fmt.Errorf("request for command %s failed", payload.Command)
 	}
 	return string(responseBody), err

--- a/tests/internal/anvil/framework.go
+++ b/tests/internal/anvil/framework.go
@@ -19,7 +19,6 @@ package anvil
 
 import (
 	"fmt"
-	"gopkg.in/square/go-jose.v2"
 	"io/ioutil"
 	"log"
 	"os"
@@ -31,6 +30,7 @@ import (
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil/am"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil/trees"
 	"github.com/dchest/uniuri"
+	"gopkg.in/square/go-jose.v2"
 )
 
 const (
@@ -177,6 +177,20 @@ func TestName(t interface{}) string {
 	return nameSlice[len(nameSlice)-1]
 }
 
+// NewFileDebugger creates a new Anvil logger that logs to file with the given test name
+func NewFileDebugger(directory, testName string) (*log.Logger, *os.File) {
+	err := os.MkdirAll(directory, 0777)
+	if err != nil {
+		log.Fatal(err)
+	}
+	file, err := os.Create(filepath.Join(directory, testName+".log"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	DebugLogger = log.New(file, "", log.Ltime|log.Lshortfile)
+	return DebugLogger, file
+}
+
 // RunTest runs the given SDKTest
 func RunTest(t SDKTest) (pass bool) {
 	name := TestName(t)
@@ -188,7 +202,9 @@ func RunTest(t SDKTest) (pass bool) {
 	if pass = t.Setup(); !pass {
 		return
 	}
+	DebugLogger.Println("*** STARTING TEST RUN")
 	pass = t.Run()
+	DebugLogger.Printf("*** RUN RESULT: %v", pass)
 	t.Cleanup()
 	return
 }

--- a/tests/iotsdk/.gitignore
+++ b/tests/iotsdk/.gitignore
@@ -1,0 +1,2 @@
+# debug logs
+debug/

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -20,7 +20,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ForgeRock/iot-edge/pkg/things"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
+)
+
+const (
+	execDir     = "./tests/iotsdk"
+	testdataDir = execDir + "/testdata"
+	debugDir    = execDir + "/debug"
 )
 
 // define the full test set
@@ -42,18 +49,21 @@ func runTests() (err error) {
 	//things.DebugLogger = anvil.DebugLogger
 
 	// create test realm
-	if err := anvil.CreatePrimaryRealm("./tests/iotsdk/testdata"); err != nil {
+	if err := anvil.CreatePrimaryRealm(testdataDir); err != nil {
 		return err
 	}
 	defer func() {
 		//_ = anvil.DeletePrimaryRealm()
 	}()
 
+	var logfile *os.File
 	allPass := true
 	for _, test := range tests {
+		things.DebugLogger, logfile = anvil.NewFileDebugger(debugDir, anvil.TestName(test))
 		if !anvil.RunTest(test) {
 			allPass = false
 		}
+		_ = logfile.Close()
 	}
 	if !allPass {
 		return fmt.Errorf("test FAILURE")


### PR DESCRIPTION
Example debug file AuthenticateWithoutConfirmationKey.log:

```
13:39:25 framework.go:205: *** STARTING TEST RUN
13:39:26 thing.go:119: *** HTTP Request ***
POST /openam/json/authenticate?realm=7RjHuFto2Fa3Rag1&authIndexType=service&authIndexValue=Anvil-User-Pwd HTTP/1.1
Host: openam.iectest.com:8080
Accept-Api-Version: protocol=1.0,resource=2.1
Content-Type: application/json

*** HTTP Response ***
HTTP/1.1 401 
Content-Length: 70
Cache-Control: private
Cache-Control: no-cache, no-store, must-revalidate
Content-Api-Version: resource=2.1
Content-Type: application/json
Date: Fri, 20 Mar 2020 13:39:25 GMT
Expires: 0
Pragma: no-cache
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN


13:39:26 framework.go:207: *** RUN RESULT: true
```

Regarding the change to debug.WriteRequest; this was done so that we get a meaningful file location entry in the debug file. For example `13:39:26 thing.go:119: *** HTTP Request ***` above. Otherwise, all the file locations were pointing to the debug file. 