### PR TITLE
IOTEDGE-919 repeat Anvil tests with the COAP client

### DIFF
--- a/pkg/iec/coapserver_test.go
+++ b/pkg/iec/coapserver_test.go
@@ -29,7 +29,7 @@ const (
 
 func TestCOAPServer_Initialise(t *testing.T) {
 	iec := NewIEC("http://127.0.0.1:8008", amtest.SimpleTestRealm)
-	if err := iec.StartCOAPServer("udp", address); err != nil {
+	if err := iec.StartCOAPServer(address); err != nil {
 		t.Fatal(err)
 	}
 	defer iec.ShutdownCOAPServer()
@@ -45,7 +45,7 @@ func TestCOAPServer_Authenticate(t *testing.T) {
 	defer am.Close()
 
 	iec := NewIEC("http://127.0.0.1:8008", amtest.SimpleTestRealm)
-	if err := iec.StartCOAPServer("udp", address); err != nil {
+	if err := iec.StartCOAPServer(address); err != nil {
 		t.Fatal(err)
 	}
 	defer iec.ShutdownCOAPServer()

--- a/pkg/iec/iec.go
+++ b/pkg/iec/iec.go
@@ -32,6 +32,7 @@ type IEC struct {
 	// coap server
 	coapServer *coap.Server
 	coapChan   chan error
+	Net        string // which protocol for COAP to use, "" defaults to UDP
 }
 
 // NewIEC creates a new IEC

--- a/pkg/things/amclient.go
+++ b/pkg/things/amclient.go
@@ -98,7 +98,7 @@ func (c *AMClient) Authenticate(authTree string, payload message.AuthenticatePay
 	}
 	if response.StatusCode != http.StatusOK {
 		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
-		return reply, errAuthRequest
+		return reply, ErrUnauthorised
 	}
 	if err = json.Unmarshal(responseBody, &reply); err != nil {
 		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))

--- a/pkg/things/coapclient.go
+++ b/pkg/things/coapclient.go
@@ -92,7 +92,7 @@ func (c COAPClient) Authenticate(authTree string, payload message.AuthenticatePa
 	}
 	if response.Code() != codes.Valid {
 		DebugLogger.Println(debug.DumpCOAPRoundTrip(conn, message, response))
-		return reply, errAuthRequest
+		return reply, ErrUnauthorised
 	}
 	if err = json.Unmarshal(response.Payload(), &reply); err != nil {
 		DebugLogger.Println(debug.DumpCOAPRoundTrip(conn, message, response))

--- a/pkg/things/thing.go
+++ b/pkg/things/thing.go
@@ -29,7 +29,7 @@ import (
 var DebugLogger = log.New(ioutil.Discard, "", 0)
 
 var (
-	errAuthRequest = errors.New("authentication request failed")
+	ErrUnauthorised = errors.New("unauthorised")
 )
 
 // Client is an interface that describes the connection to the ForgeRock platform

--- a/tests/iotsdk/authentication.go
+++ b/tests/iotsdk/authentication.go
@@ -74,7 +74,7 @@ func (t *AuthenticateWithoutConfirmationKey) Setup() (data anvil.ThingData, ok b
 func (t *AuthenticateWithoutConfirmationKey) Run(client things.Client, data anvil.ThingData) bool {
 	thing := userPwdThing(data)
 	err := thing.Initialise(client)
-	if err == nil {
+	if err != things.ErrUnauthorised {
 		return false
 	}
 	return true


### PR DESCRIPTION
* all Anvil tests are automatically run with both an AM and IEC COAP client
* COAP client and servers default to UDP but this is configurable.
* stop the AuthID being sent back to the COAP client from the IEC as its sheer size was too big for UDP. Instead it is stripped from the message and stored in the IEC. This will be properly addressed  in IOTEDGE-908.
* Debug files are put in a subdirectory called after the client used in the test. 