### PR TITLE
IOTEDGE-908 add token cache for Auth Ids

### DIFF
--- a/examples/simple/thing/main.go
+++ b/examples/simple/thing/main.go
@@ -54,7 +54,8 @@ func simpleThing() error {
 	// * AMCLient communicates directly with AM
 	// * COAPClient communicates with AM via the IEC. Run the example IEC by calling "./run.sh examples simple/iec"
 
-	client, err := things.NewAMClient(*amURL, *realm).Initialise()
+	client := things.NewAMClient(*amURL, *realm)
+	err := client.Initialise()
 	//client, err := things.NewCOAPClient("127.0.0.1:5688").Initialise()
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/go-ocf/go-coap v0.0.0-20200325133359-298a26e4e9c8
 	github.com/gorilla/mux v1.7.4
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6 // indirect
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	gopkg.in/square/go-jose.v2 v2.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/go-ocf/go-coap v0.0.0-20200325133359-298a26e4e9c8 h1:GnSy/G5ybcEwpouX
 github.com/go-ocf/go-coap v0.0.0-20200325133359-298a26e4e9c8/go.mod h1:51jqgNxk+XXTQs/yI5V8SxMbOhRfyNY7IwNFJ4Es6mU=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pion/dtls/v2 v2.0.0-rc.7 h1:LDAIQDt1pcuAIJs7Q2EZ3PSl8MseCFA2nCW0YYSYCx0=
 github.com/pion/dtls/v2 v2.0.0-rc.7/go.mod h1:U199DvHpRBN0muE9+tVN4TMy1jvEhZIZ63lk4xkvVSk=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=
@@ -27,6 +29,8 @@ golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200320220750-118fecf932d8 h1:1+zQlQqEEhUeStBTi653GZAnAuivZq/2hz+Iz+OP7rg=
 golang.org/x/net v0.0.0-20200320220750-118fecf932d8/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=

--- a/internal/mock/client.go
+++ b/internal/mock/client.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mock
+
+import (
+	"crypto"
+	"github.com/ForgeRock/iot-edge/pkg/message"
+	"github.com/dchest/uniuri"
+)
+
+// Client mocks a thing.Client
+type Client struct {
+	AuthenticateFunc func(string, message.AuthenticatePayload) (message.AuthenticatePayload, error)
+}
+
+func (m *Client) Initialise() error {
+	return nil
+}
+
+func (m *Client) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
+	if m.AuthenticateFunc != nil {
+		return m.AuthenticateFunc(authTree, payload)
+	}
+	reply.TokenId = uniuri.New()
+	return reply, nil
+}
+
+func (m *Client) SendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply string, err error) {
+	panic("implement me")
+}

--- a/internal/mock/server_test.go
+++ b/internal/mock/server_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mock
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+const testAddress = "127.0.0.1:8008"
+const testBaseURL = "http://" + testAddress
+
+func TestSimpleServer_ServerInfo(t *testing.T) {
+	server := NewSimpleServer().Start(testAddress)
+	defer server.Close()
+
+	response, err := http.Get(testBaseURL + "/json/serverinfo/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseBody, err := ioutil.ReadAll(response.Body)
+	info := struct {
+		CookieName string `json:"cookieName"`
+	}{}
+	err = json.Unmarshal(responseBody, &info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.CookieName != CookieName {
+		t.Errorf("Cookie Name isn't correct")
+	}
+}

--- a/internal/tokencache/cache.go
+++ b/internal/tokencache/cache.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tokencache
+
+import (
+	"github.com/patrickmn/go-cache"
+	"gopkg.in/square/go-jose.v2/jwt"
+	"time"
+)
+
+// Cache for signed JSON Web Tokens
+type Cache struct {
+	store *cache.Cache
+}
+
+// New creates a new token cache
+func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
+	return &Cache{store: cache.New(defaultExpiration, cleanupInterval)}
+}
+
+// unsafeClaimsOfAuthId deserialises the claims of the token without verifying them with the signature
+func unsafeClaimsOfAuthId(rawToken string) (claims jwt.Claims, ok bool) {
+	token, err := jwt.ParseSigned(rawToken)
+	if err != nil {
+		return claims, false
+	}
+
+	if err := token.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return claims, false
+	}
+	return claims, true
+}
+
+// Add the token with the cache with the given key
+func (c *Cache) Add(key, token string) {
+	// use expiry time in header if we are able to parse it, otherwise use default expiry time.
+	claims, ok := unsafeClaimsOfAuthId(token)
+	if ok && !claims.Expiry.Time().IsZero() {
+		c.store.Add(key, token, time.Until(claims.Expiry.Time()))
+	} else {
+		c.store.SetDefault(key, token)
+	}
+}
+
+// Get a token from the cache
+func (c *Cache) Get(key string) (token string, ok bool) {
+	value, ok := c.store.Get(key)
+	if !ok {
+		return "", ok
+	}
+	token, ok = value.(string)
+	return token, ok
+}

--- a/internal/tokencache/cache_test.go
+++ b/internal/tokencache/cache_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tokencache
+
+import (
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+	"testing"
+	"time"
+)
+
+// check that the token is stored only for as long as the expiry time in the header
+func TestTokenCache_Add_Expiry(t *testing.T) {
+	expiry := time.Now().Add(time.Minute + 11*time.Second).Round(time.Second)
+	key := []byte("secret")
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cl := jwt.Claims{
+		Expiry: jwt.NewNumericDate(expiry),
+	}
+	token, err := jwt.Signed(sig).Claims(cl).CompactSerialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := New(5*time.Minute, 10*time.Minute)
+	cache.Add("1", token)
+	_, cacheExpiry, ok := cache.store.GetWithExpiration("1")
+	if !ok {
+		t.Fatal("The token has not been stored")
+	}
+	// check that expiry values are the same
+	// we have to round due to loss of precision in the jwt building/parsing
+	if expiry != cacheExpiry.Round(time.Second) {
+		t.Errorf("Token expiry %v hasn't been used for store expiry %v", expiry, cacheExpiry)
+	}
+
+}

--- a/pkg/iec/coapserver.go
+++ b/pkg/iec/coapserver.go
@@ -27,9 +27,6 @@ import (
 // ErrCOAPServerAlreadyStarted indicates that a COAP server has already been started by the IEC
 var ErrCOAPServerAlreadyStarted = errors.New("COAP server has already been started")
 
-// temporary variable until IOTEDGE-908
-var authID string
-
 // authenticateHandler handles authentication requests
 func (c *IEC) authenticateHandler(w coap.ResponseWriter, r *coap.Request) {
 	DebugLogger.Println("authenticateHandler")
@@ -41,7 +38,7 @@ func (c *IEC) authenticateHandler(w coap.ResponseWriter, r *coap.Request) {
 		w.Write([]byte("Missing or incorrect auth tree"))
 		return
 	}
-	payload := message.AuthenticatePayload{AuthID: authID}
+	var payload message.AuthenticatePayload
 	if err := json.Unmarshal(r.Msg.Payload(), &payload); err != nil {
 		DebugLogger.Printf("Unable to unmarshall payload; %s", err)
 		w.SetCode(codes.BadRequest)
@@ -56,10 +53,6 @@ func (c *IEC) authenticateHandler(w coap.ResponseWriter, r *coap.Request) {
 		w.Write([]byte(err.Error()))
 		return
 	}
-
-	// remove Auth ID as it is usually too big for a single UDP message
-	authID = reply.AuthID
-	reply.AuthID = ""
 
 	b, err := json.Marshal(reply)
 	if err != nil {

--- a/pkg/iec/iec_test.go
+++ b/pkg/iec/iec_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iec
+
+import (
+	"fmt"
+	"github.com/ForgeRock/iot-edge/internal/mock"
+	"github.com/ForgeRock/iot-edge/internal/tokencache"
+	"github.com/ForgeRock/iot-edge/pkg/message"
+	"testing"
+	"time"
+)
+
+// check that the Auth Id Key is not sent to AM
+func TestIEC_Authenticate_AuthIdKey_Is_Not_Sent(t *testing.T) {
+	authId := "12345"
+	mockClient := &mock.Client{
+		AuthenticateFunc: func(_ string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
+			if payload.AuthIDKey != "" {
+				return reply, fmt.Errorf("don't send auth id digest")
+			}
+			reply.AuthId = authId
+			return reply, nil
+
+		}}
+	controller := IEC{
+		Client:    mockClient,
+		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
+	}
+	reply, err := controller.Authenticate("tree", message.AuthenticatePayload{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = controller.Authenticate("tree", reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// check that the Auth Id is not returned by the IEC to the Thing
+func TestIEC_Authenticate_AuthId_Is_Not_Returned(t *testing.T) {
+	authId := "12345"
+	mockClient := &mock.Client{
+		AuthenticateFunc: func(_ string, _ message.AuthenticatePayload) (reply message.AuthenticatePayload, _ error) {
+			reply.AuthId = authId
+			return reply, nil
+
+		}}
+	controller := IEC{
+		Client:    mockClient,
+		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
+	}
+	reply, _ := controller.Authenticate("tree", message.AuthenticatePayload{})
+	if reply.AuthId != "" {
+		t.Fatal("AuthId has been returned")
+	}
+}
+
+// check that the Auth Id is cached by the IEC
+func TestIEC_Authenticate_AuthId_Is_Cached(t *testing.T) {
+	authId := "12345"
+	mockClient := &mock.Client{
+		AuthenticateFunc: func(_ string, _ message.AuthenticatePayload) (reply message.AuthenticatePayload, _ error) {
+			reply.AuthId = authId
+			return reply, nil
+
+		}}
+	controller := IEC{
+		Client:    mockClient,
+		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
+	}
+	reply, _ := controller.Authenticate("tree", message.AuthenticatePayload{})
+	id, ok := controller.authCache.Get(reply.AuthIDKey)
+	if !ok {
+		t.Fatal("The authId has not been stored")
+	}
+	if id != authId {
+		t.Error("The stored authId is not correct")
+	}
+}

--- a/pkg/message/payload.go
+++ b/pkg/message/payload.go
@@ -23,9 +23,16 @@ import (
 
 // AuthenticatePayload represents the outbound and inbound data during an authentication request
 type AuthenticatePayload struct {
-	TokenID   string     `json:"tokenId,omitempty"`
-	AuthID    string     `json:"authId,omitempty"`
+	TokenId   string     `json:"tokenId,omitempty"`
+	AuthId    string     `json:"authId,omitempty"`
+	AuthIDKey string     `json:"auth_id_digest,omitempty"`
 	Callbacks []Callback `json:"callbacks,omitempty"`
+}
+
+// HasSessionToken returns true if the payload contains a session token
+// Indicates that the authentication workflow has completed successfully
+func (p AuthenticatePayload) HasSessionToken() bool {
+	return p.TokenId != ""
 }
 
 // CommandRequestPayload represents the outbound data during a command request

--- a/pkg/things/amclient.go
+++ b/pkg/things/amclient.go
@@ -62,13 +62,13 @@ func NewAMClient(baseURL, realm string) *AMClient {
 }
 
 // Initialise checks that the server can be reached and prepares the client for further communication
-func (c *AMClient) Initialise() (Client, error) {
+func (c *AMClient) Initialise() error {
 	info, err := c.getServerInfo()
 	if err != nil {
-		return c, err
+		return err
 	}
 	c.cookieName = info.CookieName
-	return c, nil
+	return nil
 }
 
 // Authenticate with the AM authTree using the given payload
@@ -144,7 +144,7 @@ func (c *AMClient) getServerInfo() (info serverInfo, err error) {
 	return info, err
 }
 
-func (c *AMClient) sendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (string, error) {
+func (c *AMClient) SendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (string, error) {
 	requestBody, err := signedJWTBody(signer, c.IoTURL, commandEndpointVersion, tokenID, payload)
 	DebugLogger.Println("Signed command request body: ", requestBody)
 	if err != nil {

--- a/pkg/things/coapclient.go
+++ b/pkg/things/coapclient.go
@@ -44,10 +44,10 @@ func NewCOAPClient(address string) *COAPClient {
 }
 
 // Initialise checks that the server can be reached and prepares the client for further communication
-func (c COAPClient) Initialise() (Client, error) {
+func (c COAPClient) Initialise() error {
 	conn, err := c.Dial(c.Address)
 	if err != nil {
-		return c, err
+		return err
 	}
 	defer conn.Close()
 	timeout := c.Timeout
@@ -56,7 +56,7 @@ func (c COAPClient) Initialise() (Client, error) {
 		timeout = 3600 * time.Second
 	}
 	err = conn.Ping(timeout)
-	return c, err
+	return err
 }
 
 // Authenticate with the AM authTree using the given payload
@@ -101,6 +101,6 @@ func (c COAPClient) Authenticate(authTree string, payload message.AuthenticatePa
 	return reply, nil
 }
 
-func (c COAPClient) sendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply string, err error) {
+func (c COAPClient) SendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply string, err error) {
 	return reply, fmt.Errorf("not implemented")
 }

--- a/pkg/things/coapclient_test.go
+++ b/pkg/things/coapclient_test.go
@@ -58,7 +58,7 @@ func TestCOAPClient_Initialise(t *testing.T) {
 	defer cancel()
 
 	client := NewCOAPClient(address)
-	_, err := client.Initialise()
+	err := client.Initialise()
 	if err != nil {
 		t.Error(err)
 	}
@@ -69,20 +69,20 @@ func TestCOAPClient_Authenticate(t *testing.T) {
 	defer cancel()
 
 	client := NewCOAPClient(address)
-	_, err := client.Initialise()
+	err := client.Initialise()
 	if err != nil {
 		t.Fatal(err)
 	}
 	payload := message.AuthenticatePayload{
-		TokenID:   "",
-		AuthID:    "12345",
+		TokenId:   "",
+		AuthId:    "12345",
 		Callbacks: nil,
 	}
 	reply, err := client.Authenticate(testTree, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if payload.AuthID != reply.AuthID {
+	if payload.AuthId != reply.AuthId {
 		t.Error("Expected the authentication payload echoed back to the caller")
 	}
 }

--- a/pkg/things/thing.go
+++ b/pkg/things/thing.go
@@ -35,13 +35,13 @@ var (
 // Client is an interface that describes the connection to the ForgeRock platform
 type Client interface {
 	// Initialise the client. Must be called before the Client is used by a Thing
-	Initialise() (Client, error)
+	Initialise() error
 
 	// Authenticate sends an Authenticate request to the ForgeRock platform
 	Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error)
 
-	// sendCommand sends a command request to the ForgeRock platform
-	sendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply string, err error)
+	// SendCommand sends a command request to the ForgeRock platform
+	SendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply string, err error)
 }
 
 // Thing represents an AM Thing identity
@@ -60,8 +60,8 @@ func (t Thing) authenticate(client Client) (tokenID string, err error) {
 			return tokenID, err
 		}
 
-		if payload.TokenID != "" {
-			return payload.TokenID, nil
+		if payload.HasSessionToken() {
+			return payload.TokenId, nil
 		}
 		if err = message.ProcessCallbacks(payload.Callbacks, t.Handlers); err != nil {
 			return tokenID, err
@@ -82,5 +82,5 @@ func (t Thing) SendCommand(client Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return client.sendCommand(t.Signer, tokenID, message.CommandRequestPayload{Command: "TEST"})
+	return client.SendCommand(t.Signer, tokenID, message.CommandRequestPayload{Command: "TEST"})
 }

--- a/tests/internal/anvil/framework.go
+++ b/tests/internal/anvil/framework.go
@@ -119,7 +119,6 @@ func TestCOAPClient() *things.COAPClient {
 // TestIEC creates a test IEC
 func TestIEC() *iec.IEC {
 	c := iec.NewIEC(am.AMURL, PrimaryRealm())
-	c.Client.Timeout = StdTimeOut
 	return c
 }
 

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -75,7 +75,8 @@ func runTests() (err error) {
 
 	fmt.Printf("-- Running AM Client Tests --\n\n")
 	// create AM Client
-	amClient, err := anvil.TestAMClient().Initialise()
+	amClient := anvil.TestAMClient()
+	err = amClient.Initialise()
 	if err != nil {
 		return err
 	}
@@ -92,7 +93,8 @@ func runTests() (err error) {
 	defer controller.ShutdownCOAPServer()
 
 	// create IEC Client
-	iecClient, err := anvil.TestCOAPClient().Initialise()
+	iecClient := anvil.TestCOAPClient()
+	err = iecClient.Initialise()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Added functionality to cache signed JSON web tokens. A token's expiration date is used to cleanup the cache (token is only parsed once, on addition to cache) 
- Used the token cache to store the auth ids in the IEC during an authentication workflow
