### PR TITLE
IOTEDGE-931 add access token functionality to CoAP client and IEC

### DIFF
--- a/internal/mock/client.go
+++ b/internal/mock/client.go
@@ -17,7 +17,6 @@
 package mock
 
 import (
-	"crypto"
 	"github.com/ForgeRock/iot-edge/pkg/message"
 	"github.com/dchest/uniuri"
 )
@@ -39,6 +38,10 @@ func (m *Client) Authenticate(authTree string, payload message.AuthenticatePaylo
 	return reply, nil
 }
 
-func (m *Client) SendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply string, err error) {
+func (m *Client) IoTEndpointInfo() (info message.IoTEndpoint, err error) {
+	panic("implement me")
+}
+
+func (m *Client) SendCommand(tokenID string, jws string) (reply []byte, err error) {
 	panic("implement me")
 }

--- a/pkg/iec/iec.go
+++ b/pkg/iec/iec.go
@@ -53,6 +53,11 @@ func NewIEC(baseURL, realm string) *IEC {
 	}
 }
 
+// Initialise the IEC
+func (c *IEC) Initialise() error {
+	return c.Client.Initialise()
+}
+
 // Authenticate with the AM authTree using the given payload
 func (c *IEC) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
 	if payload.AuthIDKey != "" {

--- a/pkg/message/payload.go
+++ b/pkg/message/payload.go
@@ -23,6 +23,12 @@ import (
 	"fmt"
 )
 
+// IoTEndpoint contains the information used to securely connect to the IoT Endpoint
+type IoTEndpoint struct {
+	URL     string
+	Version string
+}
+
 // AuthenticatePayload represents the outbound and inbound data during an authentication request
 type AuthenticatePayload struct {
 	TokenId   string     `json:"tokenId,omitempty"`

--- a/pkg/things/coapclient.go
+++ b/pkg/things/coapclient.go
@@ -19,15 +19,28 @@ package things
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"encoding/json"
 	"fmt"
 	"github.com/ForgeRock/iot-edge/internal/debug"
 	"github.com/ForgeRock/iot-edge/pkg/message"
 	"github.com/go-ocf/go-coap"
 	"github.com/go-ocf/go-coap/codes"
+	"strings"
 	"time"
 )
+
+type errCoAPStatusCode struct {
+	code    codes.Code
+	payload []byte
+}
+
+func (e errCoAPStatusCode) Error() string {
+	msg := fmt.Sprintf("code: %v", e.code)
+	if e.payload != nil {
+		msg += fmt.Sprintf(", payload: %s", string(e.payload))
+	}
+	return msg
+}
 
 // COAPClient contains information for connecting to the IEC via COAP
 type COAPClient struct {
@@ -59,24 +72,21 @@ func (c COAPClient) Initialise() error {
 	return err
 }
 
-// Authenticate with the AM authTree using the given payload
-func (c COAPClient) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
+type requestFunc func(conn *coap.ClientConn) (coap.Message, error)
+type responseFunc func(coap.Message) ([]byte, error)
+
+// exchange performs a synchronous query
+func (c *COAPClient) exchange(msgFunc requestFunc, postFunc responseFunc) ([]byte, error) {
 	conn, err := c.Dial(c.Address)
 	if err != nil {
-		return reply, err
+		return nil, err
 	}
 	defer conn.Close()
 
-	requestBody, err := json.Marshal(payload)
+	message, err := msgFunc(conn)
 	if err != nil {
-		return reply, err
+		return nil, err
 	}
-
-	message, err := conn.NewPostRequest("/authenticate", coap.AppJSON, bytes.NewReader(requestBody))
-	if err != nil {
-		return reply, err
-	}
-	message.SetQueryString(authTree)
 
 	ctx := context.Background()
 	if c.Timeout > 0 {
@@ -88,19 +98,78 @@ func (c COAPClient) Authenticate(authTree string, payload message.AuthenticatePa
 	response, err := conn.ExchangeWithContext(ctx, message)
 	if err != nil {
 		DebugLogger.Println(debug.DumpCOAPRoundTrip(conn, message, response))
+		return nil, err
+	}
+	return postFunc(response)
+}
+
+// Authenticate with the AM authTree using the given payload
+func (c COAPClient) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
+	requestBody, err := json.Marshal(payload)
+	if err != nil {
 		return reply, err
 	}
-	if response.Code() != codes.Valid {
-		DebugLogger.Println(debug.DumpCOAPRoundTrip(conn, message, response))
-		return reply, ErrUnauthorised
+
+	responseBody, err := c.exchange(func(conn *coap.ClientConn) (c coap.Message, err error) {
+		c, err = conn.NewPostRequest("/authenticate", coap.AppJSON, bytes.NewReader(requestBody))
+		if err != nil {
+			return
+		}
+		c.SetQueryString(authTree)
+		return
+	}, func(c coap.Message) (i []byte, err error) {
+		if c.Code() != codes.Valid {
+			return nil, ErrUnauthorised
+		}
+		return c.Payload(), nil
+	})
+	if err != nil {
+		return reply, err
 	}
-	if err = json.Unmarshal(response.Payload(), &reply); err != nil {
-		DebugLogger.Println(debug.DumpCOAPRoundTrip(conn, message, response))
+
+	if err = json.Unmarshal(responseBody, &reply); err != nil {
 		return reply, err
 	}
 	return reply, nil
 }
 
-func (c COAPClient) SendCommand(signer crypto.Signer, tokenID string, payload message.CommandRequestPayload) (reply []byte, err error) {
-	return reply, fmt.Errorf("not implemented")
+// IoTEndpointInfo returns the information required to create a valid signed JWT for the IoT endpoint
+func (c COAPClient) IoTEndpointInfo() (info message.IoTEndpoint, err error) {
+	responseBody, err := c.exchange(func(conn *coap.ClientConn) (c coap.Message, err error) {
+		c, err = conn.NewGetRequest("/iotendpointinfo")
+		if err != nil {
+			return
+		}
+		return
+	}, func(c coap.Message) (i []byte, err error) {
+		if c.Code() != codes.Content {
+			return nil, errCoAPStatusCode{c.Code(), c.Payload()}
+		}
+		return c.Payload(), nil
+	})
+	if err != nil {
+		return info, err
+	}
+
+	if err = json.Unmarshal(responseBody, &info); err != nil {
+		return info, err
+	}
+	return info, nil
+}
+
+// SendCommand sends the signed JWT to the IoT Command Endpoint
+func (c COAPClient) SendCommand(tokenID string, jws string) (reply []byte, err error) {
+	return c.exchange(func(conn *coap.ClientConn) (c coap.Message, err error) {
+		c, err = conn.NewPostRequest("/sendcommand", coap.AppJSON, strings.NewReader(jws))
+		if err != nil {
+			return
+		}
+		c.SetQueryString(tokenID)
+		return
+	}, func(c coap.Message) (i []byte, err error) {
+		if c.Code() != codes.Changed {
+			return nil, errCoAPStatusCode{c.Code(), c.Payload()}
+		}
+		return c.Payload(), nil
+	})
 }

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -94,6 +94,10 @@ func runTests() (err error) {
 
 	// run the IEC
 	controller := anvil.TestIEC()
+	err = controller.Initialise()
+	if err != nil {
+		return err
+	}
 	err = controller.StartCOAPServer(anvil.COAPAddress)
 	if err != nil {
 		return err


### PR DESCRIPTION
A valid signed JWT needs the IoT endpoint URL and version in the claim so I moved the JWT construction into the Thing and added a IoT Endpoint information request to the client interface. So the CoAP client can be request this data and it will passed down the client chain (AM Client -> IEC -> CoAP Client). In future, we should probably cache this data within the IEC.