### PR TITLE
IOTEDGE-908 consolidate packages

### DIFF
--- a/examples/simple/iec/main.go
+++ b/examples/simple/iec/main.go
@@ -20,7 +20,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"github.com/ForgeRock/iot-edge/pkg/iec"
+	"github.com/ForgeRock/iot-edge/pkg/things"
 	"log"
 	"os"
 )
@@ -31,7 +31,7 @@ var (
 )
 
 func simpleIEC() error {
-	controller := iec.NewIEC(*amURL, *realm)
+	controller := things.NewIEC(*amURL, *realm)
 
 	err := controller.StartCOAPServer("127.0.0.1:5688")
 	if err != nil {
@@ -48,7 +48,7 @@ func main() {
 	flag.Parse()
 
 	// pipe debug to standard out
-	iec.DebugLogger.SetOutput(os.Stdout)
+	things.DebugLogger.SetOutput(os.Stdout)
 
 	if err := simpleIEC(); err != nil {
 		log.Fatal(err)

--- a/examples/simple/thing/main.go
+++ b/examples/simple/thing/main.go
@@ -20,8 +20,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/ForgeRock/iot-edge/internal/crypto"
-	"github.com/ForgeRock/iot-edge/pkg/message"
 	"github.com/ForgeRock/iot-edge/pkg/things"
+	"github.com/ForgeRock/iot-edge/pkg/things/callback"
 	"log"
 	"os"
 )
@@ -53,13 +53,13 @@ func simpleThing() error {
 
 	// choose which client to use:
 	// * AMCLient communicates directly with AM
-	// * COAPClient communicates with AM via the IEC. Run the example IEC by calling "./run.sh examples simple/iec"
+	// * IECClient communicates with AM via the IEC. Run the example IEC by calling "./run.sh examples simple/iec"
 
 	var client things.Client
 	if *server == "am" {
 		client = things.NewAMClient(*amURL, *realm)
 	} else if *server == "iec" {
-		client = things.NewCOAPClient("127.0.0.1:5688")
+		client = things.NewIECClient("127.0.0.1:5688")
 	} else {
 		log.Fatal("server not supported")
 	}
@@ -78,9 +78,9 @@ func simpleThing() error {
 	thing := things.Thing{
 		Signer:   key,
 		AuthTree: *authTree,
-		Handlers: []message.CallbackHandler{
-			message.NameCallbackHandler{Name: *thingName},
-			message.PasswordCallbackHandler{Password: *thingPwd},
+		Handlers: []callback.Handler{
+			callback.NameHandler{Name: *thingName},
+			callback.PasswordHandler{Password: *thingPwd},
 		},
 	}
 	err = thing.Initialise(client)

--- a/internal/mock/client.go
+++ b/internal/mock/client.go
@@ -17,20 +17,20 @@
 package mock
 
 import (
-	"github.com/ForgeRock/iot-edge/pkg/message"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"github.com/dchest/uniuri"
 )
 
 // Client mocks a thing.Client
 type Client struct {
-	AuthenticateFunc func(string, message.AuthenticatePayload) (message.AuthenticatePayload, error)
+	AuthenticateFunc func(string, payload.Authenticate) (payload.Authenticate, error)
 }
 
 func (m *Client) Initialise() error {
 	return nil
 }
 
-func (m *Client) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
+func (m *Client) Authenticate(authTree string, payload payload.Authenticate) (reply payload.Authenticate, err error) {
 	if m.AuthenticateFunc != nil {
 		return m.AuthenticateFunc(authTree, payload)
 	}
@@ -38,7 +38,7 @@ func (m *Client) Authenticate(authTree string, payload message.AuthenticatePaylo
 	return reply, nil
 }
 
-func (m *Client) IoTEndpointInfo() (info message.IoTEndpoint, err error) {
+func (m *Client) IoTEndpointInfo() (info payload.IoTEndpoint, err error) {
 	panic("implement me")
 }
 

--- a/pkg/things/amclient.go
+++ b/pkg/things/amclient.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"github.com/ForgeRock/iot-edge/internal/amurl"
 	"github.com/ForgeRock/iot-edge/internal/debug"
-	"github.com/ForgeRock/iot-edge/pkg/message"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -76,8 +76,8 @@ func (c *AMClient) Initialise() error {
 
 // Authenticate with the AM authTree using the given payload
 // This is a single round trip
-func (c *AMClient) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
-	requestBody, err := json.Marshal(payload)
+func (c *AMClient) Authenticate(authTree string, auth payload.Authenticate) (reply payload.Authenticate, err error) {
+	requestBody, err := json.Marshal(auth)
 	if err != nil {
 		return reply, err
 	}
@@ -148,8 +148,8 @@ func (c *AMClient) getServerInfo() (info serverInfo, err error) {
 }
 
 // IoTEndpointInfo returns the information required to create a valid signed JWT for the IoT endpoint
-func (c *AMClient) IoTEndpointInfo() (info message.IoTEndpoint, err error) {
-	return message.IoTEndpoint{
+func (c *AMClient) IoTEndpointInfo() (info payload.IoTEndpoint, err error) {
+	return payload.IoTEndpoint{
 		URL:     c.IoTURL,
 		Version: commandEndpointVersion,
 	}, nil

--- a/pkg/things/amclient_test.go
+++ b/pkg/things/amclient_test.go
@@ -18,7 +18,8 @@ package things
 
 import (
 	"github.com/ForgeRock/iot-edge/internal/mock"
-	"github.com/ForgeRock/iot-edge/pkg/message"
+	"github.com/ForgeRock/iot-edge/pkg/things/callback"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"testing"
 )
 
@@ -50,20 +51,20 @@ func TestAMClient_Authenticate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	handlers := []message.CallbackHandler{message.NameCallbackHandler{Name: "test-thing"}}
-	var payload message.AuthenticatePayload
+	handlers := []callback.Handler{callback.NameHandler{Name: "test-thing"}}
+	var auth payload.Authenticate
 	for i := 0; i < 5; i++ {
-		payload, err = c.Authenticate(mock.SimpleTestAuthTree, payload)
+		auth, err = c.Authenticate(mock.SimpleTestAuthTree, auth)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = message.ProcessCallbacks(payload.Callbacks, handlers)
+		err = callback.ProcessCallbacks(auth.Callbacks, handlers)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// check that the reply has a token
-		if payload.HasSessionToken() {
+		if auth.HasSessionToken() {
 			return
 		}
 	}

--- a/pkg/things/callback/callbacks.go
+++ b/pkg/things/callback/callbacks.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package message
+package callback
 
 import (
 	"crypto"
@@ -60,7 +60,7 @@ func (c Callback) String() string {
 }
 
 // CallbackHandler is an interface for an AM callback handler
-type CallbackHandler interface {
+type Handler interface {
 	// Match returns true if the handler should respond to the callback
 	Match(Callback) bool
 	// Respond by modifying the callback
@@ -77,7 +77,7 @@ func (e ErrMissingHandler) Error() string {
 }
 
 // ProcessCallbacks attempts to respond to the callbacks with the given callback handlers
-func ProcessCallbacks(callbacks []Callback, handlers []CallbackHandler) error {
+func ProcessCallbacks(callbacks []Callback, handlers []Handler) error {
 	for _, cb := range callbacks {
 		matched := false
 	handlerLoop:
@@ -97,16 +97,16 @@ func ProcessCallbacks(callbacks []Callback, handlers []CallbackHandler) error {
 	return nil
 }
 
-// NameCallbackHandler handles an AM Username Collector callback
-type NameCallbackHandler struct {
+// NameHandler handles an AM Username Collector callback
+type NameHandler struct {
 	// Name\Username\ID for the identity
 	Name string
 }
 
-func (h NameCallbackHandler) Match(c Callback) bool {
+func (h NameHandler) Match(c Callback) bool {
 	return c.Type == TypeNameCallback
 }
-func (h NameCallbackHandler) Respond(c Callback) error {
+func (h NameHandler) Respond(c Callback) error {
 	if len(c.Input) == 0 {
 		return ErrNoInput
 	}
@@ -114,16 +114,16 @@ func (h NameCallbackHandler) Respond(c Callback) error {
 	return nil
 }
 
-// PasswordCallbackHandler handles an AM Password Collector callback
-type PasswordCallbackHandler struct {
+// PasswordHandler handles an AM Password Collector callback
+type PasswordHandler struct {
 	// Password for the identity
 	Password string
 }
 
-func (h PasswordCallbackHandler) Match(c Callback) bool {
+func (h PasswordHandler) Match(c Callback) bool {
 	return c.Type == TypePasswordCallback
 }
-func (h PasswordCallbackHandler) Respond(c Callback) error {
+func (h PasswordHandler) Respond(c Callback) error {
 	if len(c.Input) == 0 {
 		return ErrNoInput
 	}
@@ -131,20 +131,20 @@ func (h PasswordCallbackHandler) Respond(c Callback) error {
 	return nil
 }
 
-// AttributeCallbackHandler handles an AM attribute collector callback
-type AttributeCallbackHandler struct {
+// AttributeHandler handles an AM attribute collector callback
+type AttributeHandler struct {
 	// Attributes is a key-value map containing Thing attributes. Keys should match those requested by AM
 	Attributes map[string]string
 }
 
-func (h AttributeCallbackHandler) Match(c Callback) bool {
+func (h AttributeHandler) Match(c Callback) bool {
 	if c.Type != TypeTextInputCallback || len(c.Output) == 0 {
 		return false
 	}
 	_, ok := h.Attributes[c.Output[0].Value]
 	return ok
 }
-func (h AttributeCallbackHandler) Respond(c Callback) error {
+func (h AttributeHandler) Respond(c Callback) error {
 	if len(c.Input) == 0 {
 		return ErrNoInput
 	}
@@ -152,17 +152,17 @@ func (h AttributeCallbackHandler) Respond(c Callback) error {
 	return nil
 }
 
-// X509CertCallbackHandler handles an AM Certificate Collector callback
-type X509CertCallbackHandler struct {
+// X509CertificateHandler handles an AM Certificate Collector callback
+type X509CertificateHandler struct {
 	// Certificate
 	Cert []byte
 }
 
-func (h X509CertCallbackHandler) Match(c Callback) bool {
+func (h X509CertificateHandler) Match(c Callback) bool {
 	return c.Type == TypeTextInputCallback &&
 		len(c.Output) > 0 && c.Output[0].Value == PromptX509CertCallback
 }
-func (h X509CertCallbackHandler) Respond(c Callback) error {
+func (h X509CertificateHandler) Respond(c Callback) error {
 	if len(c.Input) == 0 {
 		return ErrNoInput
 	}
@@ -170,19 +170,19 @@ func (h X509CertCallbackHandler) Respond(c Callback) error {
 	return nil
 }
 
-// PoPCallbackHandler handles an AM private key proof of possession challenge
-type PoPCallbackHandler struct {
+// PoPHandler handles an AM private key proof of possession challenge
+type PoPHandler struct {
 	// Hash function used to hash the challenge
 	Hash crypto.Hash
 	// Signer function used to sign the challenge
 	Signer crypto.Signer
 }
 
-func (h PoPCallbackHandler) Match(c Callback) bool {
+func (h PoPHandler) Match(c Callback) bool {
 	return c.Type == TypeTextInputCallback &&
 		len(c.Output) > 0 && c.Output[0].Value == PromptProofOfPossessionCallback
 }
-func (h PoPCallbackHandler) Respond(c Callback) error {
+func (h PoPHandler) Respond(c Callback) error {
 	if len(c.Input) == 0 {
 		return ErrNoInput
 	}

--- a/pkg/things/callback/callbacks_test.go
+++ b/pkg/things/callback/callbacks_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package message
+package callback
 
 import (
 	"crypto"
@@ -55,30 +55,30 @@ func TestCallbackHandler_Match(t *testing.T) {
 	tests := []struct {
 		name    string
 		cb      Callback
-		handler CallbackHandler
+		handler Handler
 		want    bool
 	}{
-		// NameCallbackHandler
-		{name: "Name/True", cb: dummyCB(TypeNameCallback), handler: NameCallbackHandler{Name: "Odysseus"}, want: true},
-		{name: "Name/False", cb: dummyCB(TypeTextInputCallback), handler: NameCallbackHandler{Name: "Odysseus"}, want: false},
-		// PasswordCallbackHandler
-		{name: "Password/True", cb: dummyCB(TypePasswordCallback), handler: PasswordCallbackHandler{Password: "password"}, want: true},
-		{name: "Password/False", cb: dummyCB(TypeTextInputCallback), handler: PasswordCallbackHandler{Password: "password"}, want: false},
-		// AttributeCallbackHandler
-		{name: "Attribute/NoOutput", cb: Callback{Type: TypeTextInputCallback}, handler: AttributeCallbackHandler{Attributes: attributes}, want: false},
-		{name: "Attribute/False/WrongType", cb: dummyCB(TypeNameCallback), handler: AttributeCallbackHandler{Attributes: attributes}, want: false},
-		{name: "Attribute/False/WrongPrompt", cb: dummyCB(TypeTextInputCallback, "Wrong prompt"), handler: AttributeCallbackHandler{Attributes: attributes}, want: false},
-		{name: "Attribute/True", cb: dummyCB(TypeTextInputCallback, "thingMode"), handler: AttributeCallbackHandler{Attributes: attributes}, want: true},
-		// X509CertCallbackHandler
-		{name: "X509Cert/False/NoOutput", cb: Callback{Type: TypeTextInputCallback}, handler: X509CertCallbackHandler{Cert: []byte("12345")}, want: false},
-		{name: "X509Cert/False/WrongType", cb: dummyCB(TypeNameCallback, PromptX509CertCallback), handler: X509CertCallbackHandler{Cert: []byte("12345")}, want: false},
-		{name: "X509Cert/False/WrongPrompt", cb: dummyCB(TypeTextInputCallback, "Wrong prompt"), handler: X509CertCallbackHandler{Cert: []byte("12345")}, want: false},
-		{name: "X509Cert/True", cb: dummyCB(TypeTextInputCallback, PromptX509CertCallback), handler: X509CertCallbackHandler{Cert: []byte("12345")}, want: true},
+		// NameHandler
+		{name: "Name/True", cb: dummyCB(TypeNameCallback), handler: NameHandler{Name: "Odysseus"}, want: true},
+		{name: "Name/False", cb: dummyCB(TypeTextInputCallback), handler: NameHandler{Name: "Odysseus"}, want: false},
+		// PasswordHandler
+		{name: "Password/True", cb: dummyCB(TypePasswordCallback), handler: PasswordHandler{Password: "password"}, want: true},
+		{name: "Password/False", cb: dummyCB(TypeTextInputCallback), handler: PasswordHandler{Password: "password"}, want: false},
+		// AttributeHandler
+		{name: "Attribute/NoOutput", cb: Callback{Type: TypeTextInputCallback}, handler: AttributeHandler{Attributes: attributes}, want: false},
+		{name: "Attribute/False/WrongType", cb: dummyCB(TypeNameCallback), handler: AttributeHandler{Attributes: attributes}, want: false},
+		{name: "Attribute/False/WrongPrompt", cb: dummyCB(TypeTextInputCallback, "Wrong prompt"), handler: AttributeHandler{Attributes: attributes}, want: false},
+		{name: "Attribute/True", cb: dummyCB(TypeTextInputCallback, "thingMode"), handler: AttributeHandler{Attributes: attributes}, want: true},
+		// X509CertificateHandler
+		{name: "X509Cert/False/NoOutput", cb: Callback{Type: TypeTextInputCallback}, handler: X509CertificateHandler{Cert: []byte("12345")}, want: false},
+		{name: "X509Cert/False/WrongType", cb: dummyCB(TypeNameCallback, PromptX509CertCallback), handler: X509CertificateHandler{Cert: []byte("12345")}, want: false},
+		{name: "X509Cert/False/WrongPrompt", cb: dummyCB(TypeTextInputCallback, "Wrong prompt"), handler: X509CertificateHandler{Cert: []byte("12345")}, want: false},
+		{name: "X509Cert/True", cb: dummyCB(TypeTextInputCallback, PromptX509CertCallback), handler: X509CertificateHandler{Cert: []byte("12345")}, want: true},
 		// ProofOfPossessionCallbackHandler
-		{name: "ProofOfPossession/False/NoOutput", cb: Callback{Type: TypeTextInputCallback}, handler: PoPCallbackHandler{Hash: crypto.SHA256, Signer: key}, want: false},
-		{name: "ProofOfPossession/False/WrongType", cb: dummyCB(TypeNameCallback, PromptProofOfPossessionCallback), handler: PoPCallbackHandler{Hash: crypto.SHA256, Signer: key}, want: false},
-		{name: "ProofOfPossession/False/WrongPrompt", cb: dummyCB(TypeTextInputCallback, "Wrong prompt"), handler: PoPCallbackHandler{Hash: crypto.SHA256, Signer: key}, want: false},
-		{name: "ProofOfPossession/True", cb: dummyCB(TypeTextInputCallback, PromptProofOfPossessionCallback), handler: PoPCallbackHandler{Hash: crypto.SHA256, Signer: key}, want: true},
+		{name: "ProofOfPossession/False/NoOutput", cb: Callback{Type: TypeTextInputCallback}, handler: PoPHandler{Hash: crypto.SHA256, Signer: key}, want: false},
+		{name: "ProofOfPossession/False/WrongType", cb: dummyCB(TypeNameCallback, PromptProofOfPossessionCallback), handler: PoPHandler{Hash: crypto.SHA256, Signer: key}, want: false},
+		{name: "ProofOfPossession/False/WrongPrompt", cb: dummyCB(TypeTextInputCallback, "Wrong prompt"), handler: PoPHandler{Hash: crypto.SHA256, Signer: key}, want: false},
+		{name: "ProofOfPossession/True", cb: dummyCB(TypeTextInputCallback, PromptProofOfPossessionCallback), handler: PoPHandler{Hash: crypto.SHA256, Signer: key}, want: true},
 	}
 	for _, subtest := range tests {
 		t.Run(subtest.name, func(t *testing.T) {
@@ -95,12 +95,12 @@ func TestCallbackHandler_Respond_NoInput(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		handler CallbackHandler
+		handler Handler
 	}{
-		{name: "Name", handler: NameCallbackHandler{Name: "Odysseus"}},
-		{name: "Password", handler: PasswordCallbackHandler{Password: "password"}},
-		{name: "Attribute", handler: AttributeCallbackHandler{Attributes: attributes}},
-		{name: "X509Cert", handler: X509CertCallbackHandler{Cert: []byte("12345")}},
+		{name: "Name", handler: NameHandler{Name: "Odysseus"}},
+		{name: "Password", handler: PasswordHandler{Password: "password"}},
+		{name: "Attribute", handler: AttributeHandler{Attributes: attributes}},
+		{name: "X509Cert", handler: X509CertificateHandler{Cert: []byte("12345")}},
 	}
 	for _, subtest := range tests {
 		cb := Callback{}
@@ -124,7 +124,7 @@ func TestPoPCallbackHandler_Respond_MissingEntries(t *testing.T) {
 		{name: "NoInput", cb: Callback{Type: TypeTextInputCallback, Output: make([]Entry, 2)}},
 		{name: "NoOutput", cb: Callback{Type: TypeTextInputCallback, Input: make([]Entry, 2)}},
 	}
-	handler := PoPCallbackHandler{Hash: crypto.SHA256, Signer: key}
+	handler := PoPHandler{Hash: crypto.SHA256, Signer: key}
 	for _, subtest := range tests {
 		t.Run(subtest.name, func(t *testing.T) {
 			if err := handler.Respond(subtest.cb); err == nil {
@@ -136,7 +136,7 @@ func TestPoPCallbackHandler_Respond_MissingEntries(t *testing.T) {
 
 func TestNameCallbackHandler_Respond(t *testing.T) {
 	name := "Odysseus"
-	handler := NameCallbackHandler{Name: name}
+	handler := NameHandler{Name: name}
 	cb := dummyCB(TypeNameCallback)
 	if err := handler.Respond(cb); err != nil {
 		t.Fatal(err)
@@ -148,7 +148,7 @@ func TestNameCallbackHandler_Respond(t *testing.T) {
 
 func TestPasswordCallbackHandler_Respond(t *testing.T) {
 	p := "password"
-	handler := PasswordCallbackHandler{Password: p}
+	handler := PasswordHandler{Password: p}
 	cb := dummyCB(TypeNameCallback)
 	if err := handler.Respond(cb); err != nil {
 		t.Fatal(err)
@@ -160,7 +160,7 @@ func TestPasswordCallbackHandler_Respond(t *testing.T) {
 
 func TestX509CertCallbackHandler_Respond(t *testing.T) {
 	c := "12345"
-	handler := X509CertCallbackHandler{Cert: []byte(c)}
+	handler := X509CertificateHandler{Cert: []byte(c)}
 	cb := dummyCB(TypeNameCallback)
 	if err := handler.Respond(cb); err != nil {
 		t.Fatal(err)
@@ -175,7 +175,7 @@ func TestAttributeCallbackHandler_Respond(t *testing.T) {
 	v := "test"
 	attributes := make(map[string]string)
 	attributes[k] = v
-	handler := AttributeCallbackHandler{attributes}
+	handler := AttributeHandler{attributes}
 	cb := dummyCB(TypeNameCallback, k)
 	if err := handler.Respond(cb); err != nil {
 		t.Fatal(err)
@@ -191,7 +191,7 @@ func TestPoPCallbackHandler_Respond(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := PoPCallbackHandler{crypto.SHA256, key}
+	handler := PoPHandler{crypto.SHA256, key}
 	cb := dummyCB(TypeTextInputCallback, PromptProofOfPossessionCallback, challenge)
 	if err := handler.Respond(cb); err != nil {
 		t.Fatal(err)
@@ -216,17 +216,17 @@ func TestPoPCallbackHandler_Respond(t *testing.T) {
 
 func TestProcessCallbacks(t *testing.T) {
 	nameCB := dummyCB(TypeNameCallback)
-	nameHandler := NameCallbackHandler{Name: "Odysseus"}
+	nameHandler := NameHandler{Name: "Odysseus"}
 	pwdCB := dummyCB(TypePasswordCallback)
 
 	tests := []struct {
 		name      string
 		callbacks []Callback
-		handlers  []CallbackHandler
+		handlers  []Handler
 		ok        bool
 	}{
-		{"ok", []Callback{nameCB}, []CallbackHandler{nameHandler}, true},
-		{"error", []Callback{pwdCB}, []CallbackHandler{nameHandler}, false},
+		{"ok", []Callback{nameCB}, []Handler{nameHandler}, true},
+		{"error", []Callback{pwdCB}, []Handler{nameHandler}, false},
 	}
 	for _, subtest := range tests {
 		t.Run(subtest.name, func(t *testing.T) {

--- a/pkg/things/coapclient_test.go
+++ b/pkg/things/coapclient_test.go
@@ -17,15 +17,10 @@
 package things
 
 import (
-	"github.com/ForgeRock/iot-edge/pkg/message"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"github.com/go-ocf/go-coap"
 	"github.com/go-ocf/go-coap/codes"
 	"testing"
-)
-
-const (
-	address  = "127.0.0.1:5688"
-	testTree = "testTree"
 )
 
 func startTestServer() func() {
@@ -57,7 +52,7 @@ func TestCOAPClient_Initialise(t *testing.T) {
 	cancel := startTestServer()
 	defer cancel()
 
-	client := NewCOAPClient(address)
+	client := NewIECClient(address)
 	err := client.Initialise()
 	if err != nil {
 		t.Error(err)
@@ -68,21 +63,21 @@ func TestCOAPClient_Authenticate(t *testing.T) {
 	cancel := startTestServer()
 	defer cancel()
 
-	client := NewCOAPClient(address)
+	client := NewIECClient(address)
 	err := client.Initialise()
 	if err != nil {
 		t.Fatal(err)
 	}
-	payload := message.AuthenticatePayload{
+	auth := payload.Authenticate{
 		TokenId:   "",
 		AuthId:    "12345",
 		Callbacks: nil,
 	}
-	reply, err := client.Authenticate(testTree, payload)
+	reply, err := client.Authenticate(testTree, auth)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if payload.AuthId != reply.AuthId {
+	if auth.AuthId != reply.AuthId {
 		t.Error("Expected the authentication payload echoed back to the caller")
 	}
 }

--- a/pkg/things/iec.go
+++ b/pkg/things/iec.go
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-package iec
+package things
 
 import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"github.com/ForgeRock/iot-edge/internal/tokencache"
-	"github.com/ForgeRock/iot-edge/pkg/message"
-	"github.com/ForgeRock/iot-edge/pkg/things"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"github.com/go-ocf/go-coap"
-	"io/ioutil"
-	"log"
 	"time"
 )
 
-var DebugLogger = log.New(ioutil.Discard, "", 0)
-
-func init() {
-	things.DebugLogger = DebugLogger
-}
-
 // IEC represents an Identity Edge Controller
 type IEC struct {
-	Client    things.Client
+	Client    Client
 	authCache *tokencache.Cache
 	// coap server
 	coapServer *coap.Server
@@ -48,7 +39,7 @@ type IEC struct {
 // NewIEC creates a new IEC
 func NewIEC(baseURL, realm string) *IEC {
 	return &IEC{
-		Client:    things.NewAMClient(baseURL, realm),
+		Client:    NewAMClient(baseURL, realm),
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}
 }
@@ -59,13 +50,13 @@ func (c *IEC) Initialise() error {
 }
 
 // Authenticate with the AM authTree using the given payload
-func (c *IEC) Authenticate(authTree string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
-	if payload.AuthIDKey != "" {
-		payload.AuthId, _ = c.authCache.Get(payload.AuthIDKey)
+func (c *IEC) Authenticate(authTree string, auth payload.Authenticate) (reply payload.Authenticate, err error) {
+	if auth.AuthIDKey != "" {
+		auth.AuthId, _ = c.authCache.Get(auth.AuthIDKey)
 	}
-	payload.AuthIDKey = ""
+	auth.AuthIDKey = ""
 
-	reply, err = c.Client.Authenticate(authTree, payload)
+	reply, err = c.Client.Authenticate(authTree, auth)
 	if err != nil {
 		return
 	}

--- a/pkg/things/iec_test.go
+++ b/pkg/things/iec_test.go
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package iec
+package things
 
 import (
 	"fmt"
 	"github.com/ForgeRock/iot-edge/internal/mock"
 	"github.com/ForgeRock/iot-edge/internal/tokencache"
-	"github.com/ForgeRock/iot-edge/pkg/message"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"testing"
 	"time"
 )
@@ -29,7 +29,7 @@ import (
 func TestIEC_Authenticate_AuthIdKey_Is_Not_Sent(t *testing.T) {
 	authId := "12345"
 	mockClient := &mock.Client{
-		AuthenticateFunc: func(_ string, payload message.AuthenticatePayload) (reply message.AuthenticatePayload, err error) {
+		AuthenticateFunc: func(_ string, payload payload.Authenticate) (reply payload.Authenticate, err error) {
 			if payload.AuthIDKey != "" {
 				return reply, fmt.Errorf("don't send auth id digest")
 			}
@@ -41,7 +41,7 @@ func TestIEC_Authenticate_AuthIdKey_Is_Not_Sent(t *testing.T) {
 		Client:    mockClient,
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}
-	reply, err := controller.Authenticate("tree", message.AuthenticatePayload{})
+	reply, err := controller.Authenticate("tree", payload.Authenticate{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestIEC_Authenticate_AuthIdKey_Is_Not_Sent(t *testing.T) {
 func TestIEC_Authenticate_AuthId_Is_Not_Returned(t *testing.T) {
 	authId := "12345"
 	mockClient := &mock.Client{
-		AuthenticateFunc: func(_ string, _ message.AuthenticatePayload) (reply message.AuthenticatePayload, _ error) {
+		AuthenticateFunc: func(_ string, _ payload.Authenticate) (reply payload.Authenticate, _ error) {
 			reply.AuthId = authId
 			return reply, nil
 
@@ -64,7 +64,7 @@ func TestIEC_Authenticate_AuthId_Is_Not_Returned(t *testing.T) {
 		Client:    mockClient,
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}
-	reply, _ := controller.Authenticate("tree", message.AuthenticatePayload{})
+	reply, _ := controller.Authenticate("tree", payload.Authenticate{})
 	if reply.AuthId != "" {
 		t.Fatal("AuthId has been returned")
 	}
@@ -74,7 +74,7 @@ func TestIEC_Authenticate_AuthId_Is_Not_Returned(t *testing.T) {
 func TestIEC_Authenticate_AuthId_Is_Cached(t *testing.T) {
 	authId := "12345"
 	mockClient := &mock.Client{
-		AuthenticateFunc: func(_ string, _ message.AuthenticatePayload) (reply message.AuthenticatePayload, _ error) {
+		AuthenticateFunc: func(_ string, _ payload.Authenticate) (reply payload.Authenticate, _ error) {
 			reply.AuthId = authId
 			return reply, nil
 
@@ -83,7 +83,7 @@ func TestIEC_Authenticate_AuthId_Is_Cached(t *testing.T) {
 		Client:    mockClient,
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}
-	reply, _ := controller.Authenticate("tree", message.AuthenticatePayload{})
+	reply, _ := controller.Authenticate("tree", payload.Authenticate{})
 	id, ok := controller.authCache.Get(reply.AuthIDKey)
 	if !ok {
 		t.Fatal("The authId has not been stored")

--- a/pkg/things/jws.go
+++ b/pkg/things/jws.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package jws
+package things
 
 import (
 	"encoding/base64"
@@ -23,16 +23,16 @@ import (
 	"strings"
 )
 
-// SendCommandClaims defines the claims expected in the signed JWT provided with a Send Command request
-type SendCommandClaims struct {
+// sendCommandClaims defines the claims expected in the signed JWT provided with a Send Command request
+type sendCommandClaims struct {
 	CSRF string `json:"csrf"`
 }
 
-// ExtractPayload parses a signed JWT and unmarshals the payload into the supplied claims
+// extractJWTPayload parses a signed JWT and unmarshals the payload into the supplied claims
 // The signature is NOT checked so these claims are unverified.
 // This function exists because the JOSE library fails when parsing a signed token with a non-string nonce,
 // AM requires an integer nonce
-func ExtractPayload(token string, claims interface{}) error {
+func extractJWTPayload(token string, claims interface{}) error {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return fmt.Errorf("unexpected serialisation")

--- a/pkg/things/jws_test.go
+++ b/pkg/things/jws_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package jws
+package things
 
 import (
 	"testing"
@@ -37,7 +37,7 @@ func TestExtractPayload_Failure(t *testing.T) {
 	for _, subtest := range tests {
 		t.Run(subtest.name, func(t *testing.T) {
 			claims := dummyClaims{}
-			if err := ExtractPayload(subtest.rawToken, &claims); err == nil {
+			if err := extractJWTPayload(subtest.rawToken, &claims); err == nil {
 				t.Errorf("expected an error")
 			}
 		})
@@ -55,7 +55,7 @@ func TestExtractPayload_Success(t *testing.T) {
 	for _, subtest := range tests {
 		t.Run(subtest.name, func(t *testing.T) {
 			claims := dummyClaims{}
-			if err := ExtractPayload(subtest.rawToken, &claims); err != nil {
+			if err := extractJWTPayload(subtest.rawToken, &claims); err != nil {
 				t.Error(err)
 			} else if claims != subtest.claims {
 				t.Errorf("Expected %s, got %s", subtest.claims, claims)

--- a/pkg/things/payload/payload.go
+++ b/pkg/things/payload/payload.go
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package message
+package payload
 
 import (
 	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ForgeRock/iot-edge/pkg/things/callback"
 )
 
 // IoTEndpoint contains the information used to securely connect to the IoT Endpoint
@@ -29,17 +30,17 @@ type IoTEndpoint struct {
 	Version string
 }
 
-// AuthenticatePayload represents the outbound and inbound data during an authentication request
-type AuthenticatePayload struct {
-	TokenId   string     `json:"tokenId,omitempty"`
-	AuthId    string     `json:"authId,omitempty"`
-	AuthIDKey string     `json:"auth_id_digest,omitempty"`
-	Callbacks []Callback `json:"callbacks,omitempty"`
+// Authenticate represents the outbound and inbound data during an authentication request
+type Authenticate struct {
+	TokenId   string              `json:"tokenId,omitempty"`
+	AuthId    string              `json:"authId,omitempty"`
+	AuthIDKey string              `json:"auth_id_digest,omitempty"`
+	Callbacks []callback.Callback `json:"callbacks,omitempty"`
 }
 
 // HasSessionToken returns true if the payload contains a session token
 // Indicates that the authentication workflow has completed successfully
-func (p AuthenticatePayload) HasSessionToken() bool {
+func (p Authenticate) HasSessionToken() bool {
 	return p.TokenId != ""
 }
 
@@ -59,15 +60,15 @@ func (p getAccessTokenV1Payload) CommandID() string {
 	return p.Command
 }
 
-// NewGetAccessTokenV1Payload constructs a CommandRequestPayload for an access token V1 request
-func NewGetAccessTokenV1Payload(scope []string) CommandRequestPayload {
+// NewGetAccessTokenV1 constructs a CommandRequestPayload for an access token V1 request
+func NewGetAccessTokenV1(scope []string) CommandRequestPayload {
 	return getAccessTokenV1Payload{
 		Command: "GET_ACCESS_TOKEN_V1",
 		Scope:   scope,
 	}
 }
 
-func (p AuthenticatePayload) String() string {
+func (p Authenticate) String() string {
 	return payloadToString(p)
 }
 

--- a/tests/internal/anvil/framework.go
+++ b/tests/internal/anvil/framework.go
@@ -20,7 +20,6 @@ package anvil
 import (
 	"crypto"
 	"fmt"
-	"github.com/ForgeRock/iot-edge/pkg/iec"
 	"io/ioutil"
 	"log"
 	"os"
@@ -132,16 +131,16 @@ func TestAMClient() *things.AMClient {
 // COAPAddress is the address served by the COAP server run by the test IEC
 const COAPAddress = "127.0.0.1:5688"
 
-// TestCOAPClient creates an COAP client that connects with the test IEC instance
-func TestCOAPClient() *things.COAPClient {
-	c := things.NewCOAPClient(COAPAddress)
+// TestIECClient creates an COAP client that connects with the test IEC instance
+func TestIECClient() *things.IECClient {
+	c := things.NewIECClient(COAPAddress)
 	c.Timeout = StdTimeOut
 	return c
 }
 
 // TestIEC creates a test IEC
-func TestIEC() *iec.IEC {
-	c := iec.NewIEC(am.AMURL, PrimaryRealm())
+func TestIEC() *things.IEC {
+	c := things.NewIEC(am.AMURL, PrimaryRealm())
 	return c
 }
 

--- a/tests/iotsdk/accesstoken.go
+++ b/tests/iotsdk/accesstoken.go
@@ -17,8 +17,8 @@
 package main
 
 import (
-	"github.com/ForgeRock/iot-edge/pkg/message"
 	"github.com/ForgeRock/iot-edge/pkg/things"
+	"github.com/ForgeRock/iot-edge/pkg/things/payload"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
 	"gopkg.in/square/go-jose.v2/jwt"
 	"reflect"
@@ -183,7 +183,7 @@ func (t *AccessTokenFromCustomClient) Run(client things.Client, data anvil.Thing
 	return verifyAccessTokenResponse(response, data.Id.Name, "create", "modify", "delete")
 }
 
-func verifyAccessTokenResponse(response message.AccessTokenResponse, subject string, requestedScopes ...string) bool {
+func verifyAccessTokenResponse(response payload.AccessTokenResponse, subject string, requestedScopes ...string) bool {
 	token, err := response.AccessToken()
 	if err != nil {
 		anvil.DebugLogger.Println(err)

--- a/tests/iotsdk/authentication.go
+++ b/tests/iotsdk/authentication.go
@@ -17,8 +17,8 @@
 package main
 
 import (
-	"github.com/ForgeRock/iot-edge/pkg/message"
 	"github.com/ForgeRock/iot-edge/pkg/things"
+	"github.com/ForgeRock/iot-edge/pkg/things/callback"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
 )
 
@@ -26,9 +26,9 @@ func userPwdThing(data anvil.ThingData) *things.Thing {
 	return &things.Thing{
 		AuthTree: "Anvil-User-Pwd",
 		Signer:   data.Signer,
-		Handlers: []message.CallbackHandler{
-			message.NameCallbackHandler{Name: data.Id.Name},
-			message.PasswordCallbackHandler{Password: data.Id.Password},
+		Handlers: []callback.Handler{
+			callback.NameHandler{Name: data.Id.Name},
+			callback.PasswordHandler{Password: data.Id.Password},
 		},
 	}
 }

--- a/tests/iotsdk/examples.go
+++ b/tests/iotsdk/examples.go
@@ -50,7 +50,7 @@ func (t *SimpleThingExample) Run(client things.Client, data anvil.ThingData) boo
 	switch client.(type) {
 	case *things.AMClient:
 		server = "am"
-	case *things.COAPClient:
+	case *things.IECClient:
 		server = "iec"
 	}
 	cmd := exec.Command("go", "run", "github.com/ForgeRock/iot-edge/examples/simple/thing",

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/ForgeRock/iot-edge/pkg/iec"
 	"github.com/ForgeRock/iot-edge/pkg/things"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil/am"
@@ -53,7 +52,6 @@ func runAllTestsForClient(client things.Client) (result bool) {
 	var logfile *os.File
 	for _, test := range tests {
 		things.DebugLogger, logfile = anvil.NewFileDebugger(subDir, anvil.TypeName(test))
-		iec.DebugLogger = things.DebugLogger
 		am.DebugLogger = things.DebugLogger
 		if !anvil.RunTest(client, test) {
 			result = false
@@ -107,7 +105,7 @@ func runTests() (err error) {
 	defer controller.ShutdownCOAPServer()
 
 	// create IEC Client
-	iecClient := anvil.TestCOAPClient()
+	iecClient := anvil.TestIECClient()
 	err = iecClient.Initialise()
 	if err != nil {
 		return err


### PR DESCRIPTION
Move the IEC functionality into the things package so that the internal communication between the CoAP client and server can be fixed without making it public or moving it to a n internal package. 

pkg/things - thing and client structs, interfaces and functionality
pkg/things/callbacks - callback handlers
pkg/things/payload - data structures exposed in the external API

Now only a single debugger is required.
COAPClient renamed IECClient.

