### PR TITLE
IOTEDGE-946 simplify Thing API

### DIFF
--- a/examples/simple/thing/main.go
+++ b/examples/simple/thing/main.go
@@ -54,7 +54,6 @@ var (
 //	thingType: Device
 //	thingKeys: <see examples/resources/eckey1.jwks>
 func simpleThing() error {
-	fmt.Printf("Initialising client... ")
 
 	// choose which client to use:
 	// * AMCLient communicates directly with AM
@@ -72,11 +71,6 @@ func simpleThing() error {
 	} else {
 		log.Fatal("server not supported")
 	}
-	err := client.Initialise()
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Done\n")
 
 	key, err := crypto.LoadECPrivateKey("./examples/resources/eckey1.key.pem")
 	if err != nil {
@@ -84,22 +78,22 @@ func simpleThing() error {
 	}
 
 	fmt.Printf("Initialising %s... ", *thingName)
-	thing := things.Thing{
-		Signer:   key,
-		AuthTree: *authTree,
-		Handlers: []callback.Handler{
+	thing := things.NewThing(
+		client,
+		key,
+		*authTree,
+		[]callback.Handler{
 			callback.NameHandler{Name: *thingName},
 			callback.PasswordHandler{Password: *thingPwd},
-		},
-	}
-	err = thing.Initialise(client)
+		})
+	err = thing.Initialise()
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Done\n")
 
 	fmt.Printf("Requesting access token... ")
-	tokenResponse, err := thing.RequestAccessToken(client, "publish")
+	tokenResponse, err := thing.RequestAccessToken("publish")
 	if err != nil {
 		return err
 	}

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/pkg/things/coapserver.go
+++ b/pkg/things/coapserver.go
@@ -81,7 +81,7 @@ func (c *IEC) authenticateHandler(w coap.ResponseWriter, r *coap.Request) {
 // iotEndpointInfoHandler handles IoT Endpoint Info requests
 func (c *IEC) iotEndpointInfoHandler(w coap.ResponseWriter, r *coap.Request) {
 	DebugLogger.Println("iotEndpointInfoHandler")
-	info, err := c.Client.IoTEndpointInfo()
+	info, err := c.Thing.client.IoTEndpointInfo()
 	if err != nil {
 		w.SetCode(codes.GatewayTimeout)
 		w.Write([]byte(""))
@@ -112,7 +112,7 @@ func (c *IEC) sendCommandHandler(w coap.ResponseWriter, r *coap.Request) {
 		return
 	}
 
-	b, err := c.Client.SendCommand(claims.CSRF, payload)
+	b, err := c.Thing.client.SendCommand(claims.CSRF, payload)
 	if err != nil {
 		w.SetCode(codes.GatewayTimeout)
 		w.Write([]byte(err.Error()))

--- a/pkg/things/iec_test.go
+++ b/pkg/things/iec_test.go
@@ -65,7 +65,7 @@ func (m *mockClient) SendCommand(tokenID string, jws string) (reply []byte, err 
 
 func testIEC(client *mockClient) *IEC {
 	return &IEC{
-		Client:    client,
+		Thing:     Thing{client: client},
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}
 

--- a/tests/iotsdk/accesstoken.go
+++ b/tests/iotsdk/accesstoken.go
@@ -44,17 +44,12 @@ func (t *AccessTokenWithExactScopes) Setup(testCtx anvil.TestContext) (data anvi
 }
 
 func (t *AccessTokenWithExactScopes) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != nil {
 		return false
 	}
-	err = thing.Initialise(client)
-	if err != nil {
-		return false
-	}
-	response, err := thing.RequestAccessToken(client, "publish", "subscribe")
+	response, err := thing.RequestAccessToken("publish", "subscribe")
 	if err != nil {
 		anvil.DebugLogger.Println("access token request failed", err)
 		return false
@@ -80,17 +75,12 @@ func (t *AccessTokenWithASubsetOfScopes) Setup(testCtx anvil.TestContext) (data 
 }
 
 func (t *AccessTokenWithASubsetOfScopes) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != nil {
 		return false
 	}
-	err = thing.Initialise(client)
-	if err != nil {
-		return false
-	}
-	response, err := thing.RequestAccessToken(client, "publish")
+	response, err := thing.RequestAccessToken("publish")
 	if err != nil {
 		anvil.DebugLogger.Println("access token request failed", err)
 		return false
@@ -116,17 +106,12 @@ func (t *AccessTokenWithUnsupportedScopes) Setup(testCtx anvil.TestContext) (dat
 }
 
 func (t *AccessTokenWithUnsupportedScopes) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != nil {
 		return false
 	}
-	err = thing.Initialise(client)
-	if err != nil {
-		return false
-	}
-	_, err = thing.RequestAccessToken(client, "publish", "subscribe", "delete")
+	_, err = thing.RequestAccessToken("publish", "subscribe", "delete")
 	if err != nil && strings.Contains(err.Error(), "Unknown/invalid scope(s)") {
 		return true
 	}
@@ -153,17 +138,12 @@ func (t *AccessTokenWithNoScopes) Setup(testCtx anvil.TestContext) (data anvil.T
 }
 
 func (t *AccessTokenWithNoScopes) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != nil {
 		return false
 	}
-	err = thing.Initialise(client)
-	if err != nil {
-		return false
-	}
-	response, err := thing.RequestAccessToken(client)
+	response, err := thing.RequestAccessToken()
 	if err != nil {
 		anvil.DebugLogger.Println("access token request failed", err)
 		return false
@@ -195,17 +175,12 @@ func (t *AccessTokenFromCustomClient) Setup(testCtx anvil.TestContext) (data anv
 }
 
 func (t *AccessTokenFromCustomClient) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != nil {
 		return false
 	}
-	err = thing.Initialise(client)
-	if err != nil {
-		return false
-	}
-	response, err := thing.RequestAccessToken(client, "create", "modify", "delete")
+	response, err := thing.RequestAccessToken("create", "modify", "delete")
 	if err != nil {
 		anvil.DebugLogger.Println("access token request failed", err)
 		return false

--- a/tests/iotsdk/authentication.go
+++ b/tests/iotsdk/authentication.go
@@ -23,15 +23,15 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-func userPwdThing(data anvil.ThingData) *things.Thing {
-	return &things.Thing{
-		AuthTree: "Anvil-User-Pwd",
-		Signer:   data.Signer,
-		Handlers: []callback.Handler{
+func userPwdThing(testCtx anvil.TestContext, data anvil.ThingData) *things.Thing {
+	return things.NewThing(
+		testCtx.NewClient(),
+		data.Signer,
+		"Anvil-User-Pwd",
+		[]callback.Handler{
 			callback.NameHandler{Name: data.Id.Name},
 			callback.PasswordHandler{Password: data.Id.Password},
-		},
-	}
+		})
 }
 
 // AuthenticateWithUsernameAndPassword tests the authentication of a pre-registered device
@@ -51,13 +51,8 @@ func (t *AuthenticateWithUsernameAndPassword) Setup(testCtx anvil.TestContext) (
 }
 
 func (t *AuthenticateWithUsernameAndPassword) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
-	if err != nil {
-		return false
-	}
-	err = thing.Initialise(client)
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != nil {
 		return false
 	}
@@ -76,13 +71,8 @@ func (t *AuthenticateWithoutConfirmationKey) Setup(testCtx anvil.TestContext) (d
 }
 
 func (t *AuthenticateWithoutConfirmationKey) Run(testCtx anvil.TestContext, data anvil.ThingData) bool {
-	thing := userPwdThing(data)
-	client := testCtx.NewClient()
-	err := client.Initialise()
-	if err != nil {
-		return false
-	}
-	err = thing.Initialise(client)
+	thing := userPwdThing(testCtx, data)
+	err := thing.Initialise()
 	if err != things.ErrUnauthorised {
 		return false
 	}

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -85,7 +85,7 @@ func runAllTestsForRealm(r realm.Realm) (result bool, err error) {
 	fmt.Printf("\n\n-- Running Tests in realm %s --\n\n", r)
 
 	fmt.Printf("-- Running AM Client Tests --\n\n")
-	allPass := runAllTestsForContext(anvil.AMClientTestContext(r))
+	result = runAllTestsForContext(anvil.AMClientTestContext(r))
 
 	fmt.Printf("\n-- Running IEC COAP Client Tests --\n\n")
 
@@ -105,8 +105,8 @@ func runAllTestsForRealm(r realm.Realm) (result bool, err error) {
 	}
 	defer controller.ShutdownCOAPServer()
 
-	allPass = runAllTestsForContext(anvil.IECClientTestContext(r, controller.Address())) && allPass
-	return allPass, nil
+	result = runAllTestsForContext(anvil.IECClientTestContext(r, controller.Address())) && result
+	return result, nil
 }
 
 func runTests() (err error) {
@@ -138,7 +138,10 @@ func runTests() (err error) {
 	}
 	realmIds = append(realmIds, ids...)
 	defer func() {
-		err = anvil.DeleteRealms(realmIds)
+		deferError := anvil.DeleteRealms(realmIds)
+		if deferError != nil {
+			err = deferError
+		}
 	}()
 
 	allPass := true


### PR DESCRIPTION
- Thing uses the New creation pattern
- The client used by the Thing is fixed at creation and isn't passed in during `Initialise` or `RequestAccessToken` calls

Old API:
```
type Thing
    func (t Thing) Initialise(client Client) (err error)
    func (t Thing) RequestAccessToken(client Client, scopes ...string) (response payload.AccessTokenResponse, err error)
```
New API:
```
type Thing
    func NewThing(client Client, confirmationKey crypto.Signer, authTree string, handlers []callback.Handler) *Thing
    func (t *Thing) Initialise() (err error)
    func (t *Thing) RequestAccessToken(scopes ...string) (response payload.AccessTokenResponse, err error)
```
 
One question; do we want to restrict things that use an IEC client from selecting their own Auth Tree? We could this by moving the Auth Tree selection to the client. 