### PR TITLE
IOTEDGE-961 thing shares information with callback handlers

### DIFF
--- a/examples/simple/iec/main.go
+++ b/examples/simple/iec/main.go
@@ -54,14 +54,8 @@ func simpleIEC() error {
 	if err != nil {
 		return err
 	}
-	controller := things.NewIEC(amKey, *amURL, *amRealm, *authTree, []things.Handler{
-		things.JWTPoPAuthHandler{
-			KID:             "pop.cnf",
-			ConfirmationKey: amKey,
-			ThingID:         *iecName,
-			ThingType:       "device",
-			Realm:           *amRealm,
-		},
+	controller := things.NewIEC(things.SigningKey{KID: "pop.cnf", Signer: amKey}, *amURL, *amRealm, *authTree, []things.Handler{
+		things.ThingJWTHandler{ThingID: *iecName},
 	})
 
 	err = controller.Initialise()

--- a/examples/simple/thing/main.go
+++ b/examples/simple/thing/main.go
@@ -75,15 +75,8 @@ func simpleThing() error {
 	}
 
 	fmt.Printf("Initialising %s... ", *thingName)
-	thing := things.NewThing(client, key, []things.Handler{
-		things.JWTPoPAuthHandler{
-			KID:             "pop.cnf",
-			ConfirmationKey: key,
-			ThingID:         *thingName,
-			ThingType:       "device",
-			Realm:           *amRealm,
-		},
-	})
+	thing := things.NewThing(client, things.SigningKey{KID: "pop.cnf", Signer: key},
+		[]things.Handler{things.ThingJWTHandler{ThingID: *thingName}})
 	err = thing.Initialise()
 	if err != nil {
 		return err

--- a/pkg/things/amclient.go
+++ b/pkg/things/amclient.go
@@ -177,11 +177,12 @@ func (c *AMClient) iotURL() string {
 	return c.BaseURL + "/json/iot?_action=command&realm=" + c.Realm
 }
 
-// IoTEndpointInfo returns the information required to create a valid signed JWT for the IoT endpoint
-func (c *AMClient) IoTEndpointInfo() (info IoTEndpoint, err error) {
-	return IoTEndpoint{
-		URL:     c.iotURL(),
-		Version: commandEndpointVersion,
+// AMInfo returns AM related information to the client
+func (c *AMClient) AMInfo() (info AMInfoSet, err error) {
+	return AMInfoSet{
+		Realm:      c.Realm,
+		IoTURL:     c.iotURL(),
+		IoTVersion: commandEndpointVersion,
 	}, nil
 }
 

--- a/pkg/things/amclient_test.go
+++ b/pkg/things/amclient_test.go
@@ -181,24 +181,26 @@ func TestAMClient_Authenticate(t *testing.T) {
 	}
 }
 
-func TestAMClient_IoTEndpointInfo(t *testing.T) {
+func TestAMClient_AMInfo(t *testing.T) {
 	url := "http://same-path.org"
 	client := NewAMClient(url, testRealm, testTree)
-	info, err := client.IoTEndpointInfo()
+	info, err := client.AMInfo()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Version != commandEndpointVersion {
+	if info.Realm != testRealm {
+		t.Error("incorrect realm")
+	}
+	if info.IoTVersion != commandEndpointVersion {
 		t.Error("incorrect command endpoint version")
 	}
-	if info.URL != client.iotURL() {
+	if info.IoTURL != client.iotURL() {
 		t.Error("incorrect command endpoint url")
 	}
 }
 
 func testSendCommandHTTPMux(code int, response []byte) (mux *http.ServeMux) {
 	mux = testServerInfoHTTPMux(http.StatusOK, testServerInfo())
-	fmt.Println(testHTTPCommandEndpoint)
 	mux.HandleFunc(testHTTPCommandEndpoint, func(writer http.ResponseWriter, request *http.Request) {
 		if code != http.StatusOK {
 			http.Error(writer, string(response), code)

--- a/pkg/things/coapclient.go
+++ b/pkg/things/coapclient.go
@@ -150,8 +150,8 @@ func (c *IECClient) Authenticate(payload AuthenticatePayload) (reply Authenticat
 	return reply, nil
 }
 
-// IoTEndpointInfo returns the information required to create a valid signed JWT for the IoT endpoint
-func (c *IECClient) IoTEndpointInfo() (info IoTEndpoint, err error) {
+// AMInfo makes a request to the IEC for AM related information
+func (c *IECClient) AMInfo() (info AMInfoSet, err error) {
 	conn, err := c.dial()
 	if err != nil {
 		return info, err
@@ -160,7 +160,7 @@ func (c *IECClient) IoTEndpointInfo() (info IoTEndpoint, err error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
-	response, err := conn.GetWithContext(ctx, "/iotendpointinfo")
+	response, err := conn.GetWithContext(ctx, "/aminfo")
 	if err != nil {
 		return info, err
 	} else if response.Code() != codes.Content {

--- a/pkg/things/coapserver.go
+++ b/pkg/things/coapserver.go
@@ -72,7 +72,7 @@ func (c *IEC) authenticateHandler(w coap.ResponseWriter, r *coap.Request) {
 // iotEndpointInfoHandler handles IoT Endpoint Info requests
 func (c *IEC) iotEndpointInfoHandler(w coap.ResponseWriter, r *coap.Request) {
 	DebugLogger.Println("iotEndpointInfoHandler")
-	info, err := c.Thing.Client.IoTEndpointInfo()
+	info, err := c.Thing.Client.AMInfo()
 	if err != nil {
 		w.SetCode(codes.GatewayTimeout)
 		w.Write([]byte(""))
@@ -133,7 +133,7 @@ func (c *IEC) StartCOAPServer(address string, key crypto.Signer) error {
 	c.coapChan = make(chan error, 1)
 	mux := coap.NewServeMux()
 	mux.HandleFunc("/authenticate", c.authenticateHandler)
-	mux.HandleFunc("/iotendpointinfo", c.iotEndpointInfoHandler)
+	mux.HandleFunc("/aminfo", c.iotEndpointInfoHandler)
 	mux.HandleFunc("/sendcommand", c.sendCommandHandler)
 
 	cert, err := publicKeyCertificate(key)

--- a/pkg/things/coapserver_test.go
+++ b/pkg/things/coapserver_test.go
@@ -129,7 +129,7 @@ func TestCOAPServer_Authenticate(t *testing.T) {
 	}
 }
 
-func testCOAPServerIoTEndpointInfo(m *mockClient) (info IoTEndpoint, err error) {
+func testCOAPServerAMInfo(m *mockClient) (info AMInfoSet, err error) {
 	serverKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	iec := testIEC(m)
 	if err := iec.StartCOAPServer(":0", serverKey); err != nil {
@@ -143,28 +143,28 @@ func testCOAPServerIoTEndpointInfo(m *mockClient) (info IoTEndpoint, err error) 
 	if err != nil {
 		panic(err)
 	}
-	return client.IoTEndpointInfo()
+	return client.AMInfo()
 }
 
-func TestCOAPServer_IoTEndpointInfo(t *testing.T) {
+func TestCOAPServer_AMInfo(t *testing.T) {
 	tests := []struct {
 		name       string
 		successful bool
 		client     *mockClient
 	}{
 		{name: "success", successful: true, client: &mockClient{}},
-		{name: "endpoint-error", client: &mockClient{iotEndpointInfoFunc: func() (endpoint IoTEndpoint, err error) {
+		{name: "endpoint-error", client: &mockClient{amInfoFunc: func() (endpoint AMInfoSet, err error) {
 			return endpoint, errors.New("AM endpoint info error")
 		}}},
 	}
 	for _, subtest := range tests {
 		t.Run(subtest.name, func(t *testing.T) {
-			info, err := testCOAPServerIoTEndpointInfo(subtest.client)
+			info, err := testCOAPServerAMInfo(subtest.client)
 			if subtest.successful {
 				if err != nil {
 					t.Error(err)
-				} else if info != subtest.client.iotEndpointInfo {
-					t.Errorf("Expected info %v, got %v", subtest.client.iotEndpointInfo, info)
+				} else if info != subtest.client.amInfo {
+					t.Errorf("Expected info %v, got %v", subtest.client.amInfo, info)
 				}
 				return
 			}

--- a/pkg/things/iec.go
+++ b/pkg/things/iec.go
@@ -17,7 +17,6 @@
 package things
 
 import (
-	"crypto"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -38,12 +37,13 @@ type IEC struct {
 }
 
 // NewIEC creates a new IEC
-func NewIEC(signer crypto.Signer, baseURL string, realm string, authTree string, handlers []Handler) *IEC {
+func NewIEC(confirmationKey SigningKey, baseURL string, realm string, authTree string, handlers []Handler) *IEC {
 	return &IEC{
 		Thing: Thing{
-			confirmationKey: signer,
+			confirmationKey: confirmationKey,
 			handlers:        handlers,
 			Client:          NewAMClient(baseURL, realm, authTree),
+			thingType:       TypeIEC,
 		},
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}

--- a/pkg/things/iec_test.go
+++ b/pkg/things/iec_test.go
@@ -26,16 +26,16 @@ import (
 
 // mockClient mocks a thing.mockClient
 type mockClient struct {
-	AuthenticateFunc    func(AuthenticatePayload) (AuthenticatePayload, error)
-	iotEndpointInfoFunc func() (IoTEndpoint, error)
-	iotEndpointInfo     IoTEndpoint
-	sendCommandFunc     func(string, string) ([]byte, error)
+	AuthenticateFunc func(AuthenticatePayload) (AuthenticatePayload, error)
+	amInfoFunc       func() (AMInfoSet, error)
+	amInfo           AMInfoSet
+	sendCommandFunc  func(string, string) ([]byte, error)
 }
 
 func (m *mockClient) Initialise() error {
-	m.iotEndpointInfo = IoTEndpoint{
-		URL:     "/info",
-		Version: "1",
+	m.amInfo = AMInfoSet{
+		IoTURL:     "/info",
+		IoTVersion: "1",
 	}
 	return nil
 }
@@ -48,11 +48,11 @@ func (m *mockClient) Authenticate(payload AuthenticatePayload) (reply Authentica
 	return reply, nil
 }
 
-func (m *mockClient) IoTEndpointInfo() (info IoTEndpoint, err error) {
-	if m.iotEndpointInfoFunc != nil {
-		return m.iotEndpointInfoFunc()
+func (m *mockClient) AMInfo() (info AMInfoSet, err error) {
+	if m.amInfoFunc != nil {
+		return m.amInfoFunc()
 	}
-	return m.iotEndpointInfo, nil
+	return m.amInfo, nil
 }
 
 func (m *mockClient) SendCommand(tokenID string, jws string) (reply []byte, err error) {

--- a/pkg/things/jws.go
+++ b/pkg/things/jws.go
@@ -30,12 +30,12 @@ type sendCommandClaims struct {
 }
 
 type jwtVerifyClaims struct {
-	Sub       string `json:"sub"`
-	Aud       string `json:"aud"`
-	ThingType string `json:"thingType"`
-	Iat       int64  `json:"iat"`
-	Exp       int64  `json:"exp"`
-	Nonce     string `json:"nonce"`
+	Sub       string    `json:"sub"`
+	Aud       string    `json:"aud"`
+	ThingType ThingType `json:"thingType"`
+	Iat       int64     `json:"iat"`
+	Exp       int64     `json:"exp"`
+	Nonce     string    `json:"nonce"`
 	CNF       struct {
 		KID string           `json:"kid,omitempty"`
 		JWK *jose.JSONWebKey `json:"jwk,omitempty"`

--- a/pkg/things/payload.go
+++ b/pkg/things/payload.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 )
 
-// IoTEndpoint contains the information used to securely connect to the IoT Endpoint
-type IoTEndpoint struct {
-	URL     string
-	Version string
+// AMInfoSet contains the information required to construct valid signed JWTs
+type AMInfoSet struct {
+	Realm      string
+	IoTURL     string
+	IoTVersion string
 }
 
 // AuthenticatePayload represents the outbound and inbound data during an authentication request

--- a/tests/internal/anvil/am/amclient.go
+++ b/tests/internal/anvil/am/amclient.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/ForgeRock/iot-edge/pkg/things"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil/trees"
 	"io"
 	"io/ioutil"
@@ -255,7 +256,7 @@ func DeleteRealm(realmId string) (err error) {
 type IdAttributes struct {
 	Name                  string             `json:"username"`
 	Password              string             `json:"userPassword,omitempty"`
-	ThingType             string             `json:"thingType,omitempty"`
+	ThingType             things.ThingType   `json:"thingType,omitempty"`
 	ThingKeys             jose.JSONWebKeySet `json:"thingKeys,omitempty"`
 	ThingOAuth2ClientName string             `json:"thingOAuth2ClientName,omitempty"`
 }

--- a/tests/internal/anvil/framework.go
+++ b/tests/internal/anvil/framework.go
@@ -18,7 +18,6 @@
 package anvil
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -194,20 +193,14 @@ func TestIEC(realm string, authTree string) (*things.IEC, error) {
 		return nil, err
 	}
 	return things.NewIEC(signer, am.AMURL, realm, authTree, []things.Handler{
-		things.JWTPoPAuthHandler{
-			KID:             attributes.ThingKeys.Keys[0].KeyID,
-			ConfirmationKey: signer,
-			ThingID:         attributes.Name,
-			ThingType:       attributes.ThingType,
-			Realm:           realm,
-		},
+		things.ThingJWTHandler{ThingID: attributes.Name},
 	}), nil
 }
 
 // ThingData holds information about a Thing used in a test
 type ThingData struct {
 	Id     am.IdAttributes
-	Signer crypto.Signer
+	Signer things.SigningKey
 }
 
 // TestState contains client and realm data required to run a test

--- a/tests/internal/anvil/trees/trees.go
+++ b/tests/internal/anvil/trees/trees.go
@@ -49,7 +49,7 @@ dirLoop:
 		if !entry.IsDir() {
 			continue dirLoop
 		}
-		subdirectory := filepath.Join(directory,entry.Name())
+		subdirectory := filepath.Join(directory, entry.Name())
 		files, err := ioutil.ReadDir(subdirectory)
 		if err != nil {
 			return nodes, err
@@ -64,7 +64,7 @@ dirLoop:
 			if err != nil {
 				return nodes, err
 			}
-			nodes = append(nodes, Node{Id: nameWithoutExtension(file), Type:entry.Name(), Config:b})
+			nodes = append(nodes, Node{Id: nameWithoutExtension(file), Type: entry.Name(), Config: b})
 		}
 	}
 	return nodes, err
@@ -75,8 +75,8 @@ dirLoop:
 // Only .json files are read
 // Independent nodes are returned before dependent nodes
 func ReadNodes(rootDirectory string) (nodes []Node, err error) {
-	independent := filepath.Join(rootDirectory,"independent")
-	dependent := filepath.Join(rootDirectory,"dependent")
+	independent := filepath.Join(rootDirectory, "independent")
+	dependent := filepath.Join(rootDirectory, "dependent")
 	if _, err := os.Stat(independent); err == nil {
 		nodes, err = readNodeSet(nodes, independent)
 		if err != nil {
@@ -107,7 +107,7 @@ func ReadTrees(dirname string) (trees []Tree, err error) {
 		if err != nil {
 			return
 		}
-		trees = append(trees, Tree{Id: nameWithoutExtension(f), Config:b})
+		trees = append(trees, Tree{Id: nameWithoutExtension(f), Config: b})
 	}
 	return
 }

--- a/tests/iotsdk/accesstoken.go
+++ b/tests/iotsdk/accesstoken.go
@@ -39,12 +39,12 @@ func (t *AccessTokenWithExactScopes) Setup(state anvil.TestState) (data anvil.Th
 		anvil.DebugLogger.Println("failed to generate confirmation key", err)
 		return data, false
 	}
-	data.Id.ThingType = "Device"
+	data.Id.ThingType = things.TypeDevice
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 
 func (t *AccessTokenWithExactScopes) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := jwtPoPAuthThing(state, data)
+	thing := thingJWTAuth(state, data)
 	err := thing.Initialise()
 	if err != nil {
 		return false
@@ -70,12 +70,12 @@ func (t *AccessTokenWithASubsetOfScopes) Setup(state anvil.TestState) (data anvi
 		anvil.DebugLogger.Println("failed to generate confirmation key", err)
 		return data, false
 	}
-	data.Id.ThingType = "Device"
+	data.Id.ThingType = things.TypeDevice
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 
 func (t *AccessTokenWithASubsetOfScopes) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := jwtPoPAuthThing(state, data)
+	thing := thingJWTAuth(state, data)
 	err := thing.Initialise()
 	if err != nil {
 		return false
@@ -101,12 +101,12 @@ func (t *AccessTokenWithUnsupportedScopes) Setup(state anvil.TestState) (data an
 		anvil.DebugLogger.Println("failed to generate confirmation key", err)
 		return data, false
 	}
-	data.Id.ThingType = "Device"
+	data.Id.ThingType = things.TypeDevice
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 
 func (t *AccessTokenWithUnsupportedScopes) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := jwtPoPAuthThing(state, data)
+	thing := thingJWTAuth(state, data)
 	err := thing.Initialise()
 	if err != nil {
 		return false
@@ -133,12 +133,12 @@ func (t *AccessTokenWithNoScopes) Setup(state anvil.TestState) (data anvil.Thing
 		anvil.DebugLogger.Println("failed to generate confirmation key", err)
 		return data, false
 	}
-	data.Id.ThingType = "Device"
+	data.Id.ThingType = things.TypeDevice
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 
 func (t *AccessTokenWithNoScopes) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := jwtPoPAuthThing(state, data)
+	thing := thingJWTAuth(state, data)
 	err := thing.Initialise()
 	if err != nil {
 		return false
@@ -169,13 +169,13 @@ func (t *AccessTokenFromCustomClient) Setup(state anvil.TestState) (data anvil.T
 		anvil.DebugLogger.Println("failed to generate confirmation key", err)
 		return data, false
 	}
-	data.Id.ThingType = "Device"
+	data.Id.ThingType = things.TypeDevice
 	data.Id.ThingOAuth2ClientName = "thing-oauth2-client"
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 
 func (t *AccessTokenFromCustomClient) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := jwtPoPAuthThing(state, data)
+	thing := thingJWTAuth(state, data)
 	err := thing.Initialise()
 	if err != nil {
 		return false

--- a/tests/iotsdk/examples.go
+++ b/tests/iotsdk/examples.go
@@ -57,7 +57,7 @@ func (t *SimpleThingExample) Setup(state anvil.TestState) (data anvil.ThingData,
 		return data, false
 	}
 	data.Id.ThingKeys = jose.JSONWebKeySet{Keys: []jose.JSONWebKey{verifier}}
-	data.Id.ThingType = "Device"
+	data.Id.ThingType = things.TypeDevice
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 
@@ -116,7 +116,7 @@ func (t *SimpleIECExample) Setup(state anvil.TestState) (data anvil.ThingData, o
 		return data, false
 	}
 	data.Id.ThingKeys = jose.JSONWebKeySet{Keys: []jose.JSONWebKey{verifier}}
-	data.Id.ThingType = "iec"
+	data.Id.ThingType = things.TypeIEC
 	return anvil.CreateIdentity(state.Realm(), data)
 }
 

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -40,7 +40,8 @@ const (
 
 // define the full test set
 var tests = []anvil.SDKTest{
-	&AuthenticateWithJWTPoP{},
+	&AuthenticateThingJWT{},
+	&AuthenticateThingJWTNonDefaultKID{},
 	&AuthenticateWithoutConfirmationKey{},
 	&AccessTokenWithExactScopes{},
 	&AccessTokenWithASubsetOfScopes{},


### PR DESCRIPTION
Simpler Thing construction:
```
thing := things.NewThing(client, things.SigningKey{KID: "pop.cnf", Signer: key},
		[]things.Handler{things.ThingJWTHandler{ThingID: *thingName}})
```

* New interface to allow callback handlers to request information from the Thing. Stops information duplication and allows dynamic updating e.g. new confirmation key
* Changed IoT Endpoint info to the more generic AM info in the client interface. We needed the AM realm to construct the authentication JWT but a IEC client is not initialised with this information. 
* New struct to hold a signing key; just a crypt signer and a kid. If a Thing is initialised or modified to use a confirmation key that doesn’t have a kid, the key’s thumbprint is used as the kid. 
