### PR TITLE
IOTEDGE-974 add session struct and move cnf key to handlers

### DIFF
--- a/examples/iec/simple/main.go
+++ b/examples/iec/simple/main.go
@@ -79,10 +79,9 @@ func simpleIEC() error {
 	if err != nil {
 		return err
 	}
-	controller := things.NewIEC(things.SigningKey{KID: *keyID, Signer: amKey}, *amURL, *amRealm, *authTree,
-		[]things.Handler{
-			things.AuthenticateHandler{ThingID: *iecName},
-		})
+	controller := things.NewIEC(*amURL, *amRealm, *authTree, []things.Handler{
+		things.AuthenticateHandler{ThingID: *iecName, ConfirmationKeyID: *keyID, ConfirmationKey: amKey},
+	})
 
 	err = controller.Initialise()
 	if err != nil {

--- a/examples/thing/cert-registration/main.go
+++ b/examples/thing/cert-registration/main.go
@@ -102,7 +102,6 @@ func certRegThing() (err error) {
 
 	var client things.Client
 	if *server == "am" {
-		fmt.Println(*authTree)
 		client = things.NewAMClient(*amURL, *amRealm, *authTree)
 	} else if *server == "iec" {
 		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -124,16 +123,12 @@ func certRegThing() (err error) {
 		return err
 	}
 
-	fmt.Printf("Initialising %s... ", *thingName)
-	thing := things.NewThing(client, things.SigningKey{KID: *keyID, Signer: signer},
-		[]things.Handler{
-			things.AuthenticateHandler{ThingID: *thingName},
-			things.RegisterHandler{ThingID: *thingName, ThingType: things.TypeDevice, Certificates: certs},
-		})
-	err = thing.Initialise()
-	if err != nil {
-		return err
-	}
+	fmt.Printf("Creating Thing %s... ", *thingName)
+	thing := things.NewThing(client, []things.Handler{
+		things.AuthenticateHandler{ThingID: *thingName, ConfirmationKeyID: *keyID, ConfirmationKey: signer},
+		things.RegisterHandler{ThingID: *thingName, ThingType: things.TypeDevice, ConfirmationKeyID: *keyID,
+			ConfirmationKey: signer, Certificates: certs},
+	})
 	fmt.Printf("Done\n")
 
 	fmt.Printf("Requesting access token... ")

--- a/examples/thing/simple/main.go
+++ b/examples/thing/simple/main.go
@@ -99,13 +99,10 @@ func simpleThing() error {
 		return err
 	}
 
-	fmt.Printf("Initialising %s... ", *thingName)
-	thing := things.NewThing(client, things.SigningKey{KID: *keyID, Signer: key},
-		[]things.Handler{things.AuthenticateHandler{ThingID: *thingName}})
-	err = thing.Initialise()
-	if err != nil {
-		return err
-	}
+	fmt.Printf("Creating Thing %s... ", *thingName)
+	thing := things.NewThing(client, []things.Handler{
+		things.AuthenticateHandler{ThingID: *thingName, ConfirmationKeyID: *keyID, ConfirmationKey: key},
+	})
 	fmt.Printf("Done\n")
 
 	fmt.Printf("Requesting access token... ")

--- a/pkg/things/iec.go
+++ b/pkg/things/iec.go
@@ -37,12 +37,11 @@ type IEC struct {
 }
 
 // NewIEC creates a new IEC
-func NewIEC(confirmationKey SigningKey, baseURL string, realm string, authTree string, handlers []Handler) *IEC {
+func NewIEC(baseURL string, realm string, authTree string, handlers []Handler) *IEC {
 	return &IEC{
 		Thing: Thing{
-			confirmationKey: confirmationKey,
-			handlers:        handlers,
-			Client:          NewAMClient(baseURL, realm, authTree),
+			Client:   NewAMClient(baseURL, realm, authTree),
+			handlers: handlers,
 		},
 		authCache: tokencache.New(5*time.Minute, 10*time.Minute),
 	}
@@ -50,7 +49,8 @@ func NewIEC(confirmationKey SigningKey, baseURL string, realm string, authTree s
 
 // Initialise the IEC
 func (c *IEC) Initialise() error {
-	return c.Thing.Initialise()
+	_, err := c.Thing.Session()
+	return err
 }
 
 // Authenticate a Thing with AM using the given payload

--- a/tests/internal/anvil/crypto.go
+++ b/tests/internal/anvil/crypto.go
@@ -25,12 +25,11 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"fmt"
-	"github.com/ForgeRock/iot-edge/pkg/things"
 	jose "gopkg.in/square/go-jose.v2"
 )
 
 // GenerateConfirmationKey generates a key for signing requests to AM that is accompanied by a restricted PoP SSO token.
-func GenerateConfirmationKey(algorithm jose.SignatureAlgorithm) (public jose.JSONWebKeySet, private things.SigningKey, err error) {
+func GenerateConfirmationKey(algorithm jose.SignatureAlgorithm) (public jose.JSONWebKeySet, private SigningKey, err error) {
 	// create a new key
 	switch algorithm {
 	case jose.ES256:
@@ -62,4 +61,10 @@ func GenerateConfirmationKey(algorithm jose.SignatureAlgorithm) (public jose.JSO
 	webKey.KeyID = base64.URLEncoding.EncodeToString(kid)
 	private.KID = webKey.KeyID
 	return jose.JSONWebKeySet{Keys: []jose.JSONWebKey{webKey}}, private, nil
+}
+
+// SigningKey describes a key used for signing messages sent to AM
+type SigningKey struct {
+	KID    string
+	Signer crypto.Signer
 }

--- a/tests/internal/anvil/framework.go
+++ b/tests/internal/anvil/framework.go
@@ -316,15 +316,15 @@ func TestIEC(realm string, authTree string) (*things.IEC, error) {
 	if err != nil {
 		return nil, err
 	}
-	return things.NewIEC(signer, am.AMURL, realm, authTree, []things.Handler{
-		things.AuthenticateHandler{ThingID: attributes.Name},
+	return things.NewIEC(am.AMURL, realm, authTree, []things.Handler{
+		things.AuthenticateHandler{ThingID: attributes.Name, ConfirmationKeyID: signer.KID, ConfirmationKey: signer.Signer},
 	}), nil
 }
 
 // ThingData holds information about a Thing used in a test
 type ThingData struct {
 	Id           am.IdAttributes
-	Signer       things.SigningKey
+	Signer       SigningKey
 	Certificates []*x509.Certificate
 }
 

--- a/tests/iotsdk/authentication.go
+++ b/tests/iotsdk/authentication.go
@@ -23,8 +23,8 @@ import (
 )
 
 func thingJWTAuth(state anvil.TestState, data anvil.ThingData) *things.Thing {
-	return things.NewThing(state.InitClients(jwtPopAuthTree), data.Signer, []things.Handler{
-		things.AuthenticateHandler{ThingID: data.Id.Name},
+	return things.NewThing(state.InitClients(jwtPopAuthTree), []things.Handler{
+		things.AuthenticateHandler{ThingID: data.Id.Name, ConfirmationKeyID: data.Signer.KID, ConfirmationKey: data.Signer.Signer},
 	})
 }
 
@@ -46,7 +46,7 @@ func (t *AuthenticateThingJWT) Setup(state anvil.TestState) (data anvil.ThingDat
 
 func (t *AuthenticateThingJWT) Run(state anvil.TestState, data anvil.ThingData) bool {
 	thing := thingJWTAuth(state, data)
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != nil {
 		return false
 	}
@@ -75,7 +75,7 @@ func (t *AuthenticateThingJWTNonDefaultKID) Setup(state anvil.TestState) (data a
 
 func (t *AuthenticateThingJWTNonDefaultKID) Run(state anvil.TestState, data anvil.ThingData) bool {
 	thing := thingJWTAuth(state, data)
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != nil {
 		return false
 	}
@@ -102,7 +102,7 @@ func (t *AuthenticateWithoutConfirmationKey) Run(state anvil.TestState, data anv
 		return false
 	}
 	thing := thingJWTAuth(state, data)
-	err = thing.Initialise()
+	_, err = thing.Session()
 	if err != things.ErrUnauthorised {
 		anvil.DebugLogger.Println(err)
 		return false
@@ -128,14 +128,15 @@ func (t *AuthenticateWithCustomClaims) Setup(state anvil.TestState) (data anvil.
 }
 
 func (t *AuthenticateWithCustomClaims) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := things.NewThing(state.InitClients(jwtPopAuthTreeCustomClaims), data.Signer, []things.Handler{
-		things.AuthenticateHandler{ThingID: data.Id.Name, Claims: func() interface{} {
-			return struct {
-				LifeUniverseEverything string `json:"life_universe_everything"`
-			}{"42"}
-		}},
+	thing := things.NewThing(state.InitClients(jwtPopAuthTreeCustomClaims), []things.Handler{
+		things.AuthenticateHandler{ThingID: data.Id.Name, ConfirmationKeyID: data.Signer.KID, ConfirmationKey: data.Signer.Signer,
+			Claims: func() interface{} {
+				return struct {
+					LifeUniverseEverything string `json:"life_universe_everything"`
+				}{"42"}
+			}},
 	})
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != nil {
 		return false
 	}
@@ -160,14 +161,15 @@ func (t *AuthenticateWithIncorrectCustomClaim) Setup(state anvil.TestState) (dat
 }
 
 func (t *AuthenticateWithIncorrectCustomClaim) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := things.NewThing(state.InitClients(jwtPopAuthTreeCustomClaims), data.Signer, []things.Handler{
-		things.AuthenticateHandler{ThingID: data.Id.Name, Claims: func() interface{} {
-			return struct {
-				LifeUniverseEverything string `json:"life_universe_everything"`
-			}{"0"}
-		}},
+	thing := things.NewThing(state.InitClients(jwtPopAuthTreeCustomClaims), []things.Handler{
+		things.AuthenticateHandler{ThingID: data.Id.Name, ConfirmationKeyID: data.Signer.KID, ConfirmationKey: data.Signer.Signer,
+			Claims: func() interface{} {
+				return struct {
+					LifeUniverseEverything string `json:"life_universe_everything"`
+				}{"0"}
+			}},
 	})
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != things.ErrUnauthorised {
 		anvil.DebugLogger.Println(err)
 		return false

--- a/tests/iotsdk/main.go
+++ b/tests/iotsdk/main.go
@@ -62,6 +62,7 @@ var tests = []anvil.SDKTest{
 	//&AccessTokenWithNoScopes{alg: jose.PS384},
 	//&AccessTokenWithNoScopes{alg: jose.PS512},
 	&AccessTokenFromCustomClient{},
+	&AccessTokenRepeat{},
 	&SimpleThingExample{},
 	&SimpleIECExample{},
 	&CertRegistrationExample{},

--- a/tests/iotsdk/registration.go
+++ b/tests/iotsdk/registration.go
@@ -51,11 +51,12 @@ func (t *RegisterThingCert) Setup(state anvil.TestState) (data anvil.ThingData, 
 }
 
 func (t *RegisterThingCert) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := things.NewThing(state.InitClients(jwtPopRegCertTree), data.Signer, []things.Handler{
-		things.AuthenticateHandler{ThingID: data.Id.Name},
-		things.RegisterHandler{ThingID: data.Id.Name, ThingType: things.TypeDevice, Certificates: data.Certificates},
+	thing := things.NewThing(state.InitClients(jwtPopRegCertTree), []things.Handler{
+		things.AuthenticateHandler{ThingID: data.Id.Name, ConfirmationKeyID: data.Signer.KID, ConfirmationKey: data.Signer.Signer},
+		things.RegisterHandler{ThingID: data.Id.Name, ThingType: things.TypeDevice, ConfirmationKeyID: data.Signer.KID,
+			ConfirmationKey: data.Signer.Signer, Certificates: data.Certificates},
 	})
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != nil {
 		return false
 	}
@@ -81,11 +82,12 @@ func (t *RegisterThingWithoutCert) Setup(state anvil.TestState) (data anvil.Thin
 }
 
 func (t *RegisterThingWithoutCert) Run(state anvil.TestState, data anvil.ThingData) bool {
-	thing := things.NewThing(state.InitClients(jwtPopRegCertTree), data.Signer, []things.Handler{
-		things.AuthenticateHandler{ThingID: data.Id.Name},
-		things.RegisterHandler{ThingID: data.Id.Name, ThingType: things.TypeDevice, Certificates: data.Certificates},
+	thing := things.NewThing(state.InitClients(jwtPopRegCertTree), []things.Handler{
+		things.AuthenticateHandler{ThingID: data.Id.Name, ConfirmationKeyID: data.Signer.KID, ConfirmationKey: data.Signer.Signer},
+		things.RegisterHandler{ThingID: data.Id.Name, ThingType: things.TypeDevice, ConfirmationKeyID: data.Signer.KID,
+			ConfirmationKey: data.Signer.Signer},
 	})
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != things.ErrUnauthorised {
 		anvil.DebugLogger.Printf("Expected Not Authorised; got %v", err)
 		return false
@@ -128,14 +130,14 @@ func (t *RegisterThingWithAttributes) Run(state anvil.TestState, data anvil.Thin
 	amAttribute := struct {
 		EmployeeNumber []string `json:"employeeNumber"`
 	}{}
-	thing := things.NewThing(state.InitClients(jwtPopRegCertTree), data.Signer, []things.Handler{
-		things.AuthenticateHandler{ThingID: data.Id.Name},
-		things.RegisterHandler{ThingID: data.Id.Name, ThingType: things.TypeDevice, Certificates: data.Certificates,
-			Claims: func() interface{} {
+	thing := things.NewThing(state.InitClients(jwtPopRegCertTree), []things.Handler{
+		things.AuthenticateHandler{ThingID: data.Id.Name, ConfirmationKeyID: data.Signer.KID, ConfirmationKey: data.Signer.Signer},
+		things.RegisterHandler{ThingID: data.Id.Name, ThingType: things.TypeDevice, ConfirmationKeyID: data.Signer.KID,
+			ConfirmationKey: data.Signer.Signer, Certificates: data.Certificates, Claims: func() interface{} {
 				return sdkAttribute
 			}},
 	})
-	err := thing.Initialise()
+	_, err := thing.Session()
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
- Moved the confirmation key into Thing authenticate and registration callback handlers
- replaced the Initialise method with the Session method which returns a Session struct 

New Session and Thing API:
```
type Session
    func (s *Session) ConfirmationKey() crypto.Signer
    func (s *Session) HasRestrictedToken() bool
    func (s *Session) IncrementNonce()
    func (s *Session) Nonce() int
    func (s *Session) Token() string
type Thing
    func NewThing(client Client, handlers []Handler) *Thing
    func (t *Thing) Realm() string
    func (t *Thing) RequestAccessToken(scopes ...string) (response AccessTokenResponse, err error)
    func (t *Thing) Session() (session *Session, err error)
```
I have added IOTEDGE-975 to capture the work required to handle the lifecycle of the session.
