### PR TITLE
Add documentation and license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![GoDoc](https://godoc.org/github.com/ForgeRock/iot-edge/pkg/things?status.svg)](https://godoc.org/github.com/ForgeRock/iot-edge/pkg/things)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ForgeRock/iot-edge/blob/main/LICENSE)
+
 # ForgeRock IoT Edge
 
 ForgeRock IoT Edge is an open source project containing the IoT edge tier components of the ForgeRock Identity Platform.


### PR DESCRIPTION
Added our docs to godoc.org and added a documentation and license badge to the README.

<img width="1078" alt="Screenshot 2020-06-18 at 18 16 34" src="https://user-images.githubusercontent.com/15840685/85051999-24430380-b190-11ea-9ab2-18f295f25f6f.png">
