### PR TITLE
IOTEDGE-981 update godoc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GoDoc](https://godoc.org/github.com/ForgeRock/iot-edge/pkg/things?status.svg)](https://godoc.org/github.com/ForgeRock/iot-edge/pkg/things)
+[![GoDoc](https://godoc.org/github.com/ForgeRock/iot-edge/pkg?status.svg)](https://godoc.org/github.com/ForgeRock/iot-edge/pkg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ForgeRock/iot-edge/blob/main/LICENSE)
 
 # ForgeRock IoT Edge


### PR DESCRIPTION
I was going to move over to the new documentation site https://pkg.go.dev but they don't a standard badge yet and everyone likes a shiny badge. I have updated the documentation served at pkg.go.dev for [iot-edge](https://pkg.go.dev/github.com/ForgeRock/iot-edge/pkg) 