### PR TITLE
IOTEDGE-981 Remove circular dependency between thing and session

### DIFF
--- a/examples/gateway/simple/main.go
+++ b/examples/gateway/simple/main.go
@@ -26,6 +26,7 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"github.com/ForgeRock/iot-edge/internal/gateway"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"io/ioutil"
@@ -81,7 +82,7 @@ func simpleThingGateway() error {
 	if err != nil {
 		return err
 	}
-	gateway := thing.NewThingGateway(*amURL, *amRealm, *authTree, []callback.Handler{
+	gateway := gateway.NewThingGateway(*amURL, *amRealm, *authTree, []callback.Handler{
 		callback.AuthenticateHandler{
 			Realm:   *amRealm,
 			ThingID: *gatewayName,
@@ -113,7 +114,7 @@ func main() {
 	flag.Parse()
 
 	// pipe debug to standard out
-	thing.DebugLogger.SetOutput(os.Stdout)
+	thing.DebugLogger().SetOutput(os.Stdout)
 
 	if err := simpleThingGateway(); err != nil {
 		log.Fatal(err)

--- a/examples/thing/cert-registration/main.go
+++ b/examples/thing/cert-registration/main.go
@@ -22,6 +22,7 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"github.com/ForgeRock/iot-edge/pkg/builder"
 	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"io/ioutil"
 	"log"
@@ -113,7 +114,7 @@ func certRegThing() (err error) {
 		return err
 	}
 
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(u).
 		InRealm(*realm).
 		WithTree(*authTree).
@@ -156,7 +157,7 @@ func main() {
 	flag.Parse()
 
 	// pipe debug to standard out
-	thing.DebugLogger.SetOutput(os.Stdout)
+	thing.DebugLogger().SetOutput(os.Stdout)
 
 	if err := certRegThing(); err != nil {
 		log.Fatal(err)

--- a/examples/thing/simple/main.go
+++ b/examples/thing/simple/main.go
@@ -22,6 +22,7 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"github.com/ForgeRock/iot-edge/pkg/builder"
 	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"io/ioutil"
 	"log"
@@ -83,7 +84,7 @@ func simpleThing() error {
 		return err
 	}
 
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(u).
 		InRealm(*realm).
 		WithTree(*authTree).
@@ -125,7 +126,7 @@ func main() {
 	flag.Parse()
 
 	// pipe debug to standard out
-	thing.DebugLogger.SetOutput(os.Stdout)
+	thing.DebugLogger().SetOutput(os.Stdout)
 
 	if err := simpleThing(); err != nil {
 		log.Fatal(err)

--- a/internal/client/amconn.go
+++ b/internal/client/amconn.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package thing
+package client
 
 import (
 	"bytes"
@@ -60,43 +60,43 @@ func (c *amConnection) newSessionRequest(tokenID string, action string) (request
 	}
 
 	request.Header.Add(acceptAPIVersion, sessionEndpointVersion)
-	request.Header.Add(httpContentType, string(applicationJSON))
+	request.Header.Add(httpContentType, string(ApplicationJSON))
 	request.AddCookie(&http.Cookie{Name: c.cookieName, Value: tokenID})
 	return request, nil
 }
 
 // logoutSession represented by the given token
-func (c *amConnection) logoutSession(tokenID string) (err error) {
+func (c *amConnection) LogoutSession(tokenID string) (err error) {
 	request, err := c.newSessionRequest(tokenID, "logout")
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, nil))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, nil))
 		return err
 	}
 
 	response, err := c.Do(request)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return err
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return fmt.Errorf("session logout failed")
 	}
 	return nil
 }
 
 // validateSession represented by the given token
-func (c *amConnection) validateSession(tokenID string) (ok bool, err error) {
+func (c *amConnection) ValidateSession(tokenID string) (ok bool, err error) {
 	request, err := c.newSessionRequest(tokenID, "validate")
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, nil))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, nil))
 		return false, err
 	}
 
 	response, err := c.Do(request)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return false, err
 	}
 	defer response.Body.Close()
@@ -106,13 +106,13 @@ func (c *amConnection) validateSession(tokenID string) (ok bool, err error) {
 	case http.StatusUnauthorized:
 		return false, nil
 	default:
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return false, fmt.Errorf("session validation failed")
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return false, err
 	}
 	info := struct {
@@ -148,7 +148,7 @@ func parseAMError(response []byte, status int) error {
 }
 
 // initialise checks that the server can be reached and prepares the client for further communication
-func (c *amConnection) initialise() error {
+func (c *amConnection) Initialise() error {
 	info, err := c.getServerInfo()
 	if err != nil {
 		return err
@@ -159,14 +159,14 @@ func (c *amConnection) initialise() error {
 
 // authenticate with the AM authTree using the given payload
 // This is a single round trip
-func (c *amConnection) authenticate(payload authenticatePayload) (reply authenticatePayload, err error) {
+func (c *amConnection) Authenticate(payload AuthenticatePayload) (reply AuthenticatePayload, err error) {
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
 		return reply, err
 	}
 	request, err := http.NewRequest(http.MethodPost, c.baseURL+"/json/authenticate", bytes.NewBuffer(requestBody))
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, nil))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, nil))
 		return reply, err
 	}
 
@@ -178,24 +178,24 @@ func (c *amConnection) authenticate(payload authenticatePayload) (reply authenti
 	request.URL.RawQuery = q.Encode()
 
 	request.Header.Add(acceptAPIVersion, authNEndpointVersion)
-	request.Header.Add(httpContentType, string(applicationJSON))
+	request.Header.Add(httpContentType, string(ApplicationJSON))
 	response, err := c.Do(request)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return reply, err
 	}
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return reply, err
 	}
 	if response.StatusCode != http.StatusOK {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return reply, ErrUnauthorised
 	}
 	if err = json.Unmarshal(responseBody, &reply); err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return reply, err
 	}
 	return reply, err
@@ -210,7 +210,7 @@ type serverInfo struct {
 func (c *amConnection) getServerInfo() (info serverInfo, err error) {
 	request, err := http.NewRequest(http.MethodGet, c.baseURL+"/json/serverinfo/*", nil)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, nil))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, nil))
 		return info, err
 	}
 
@@ -219,24 +219,24 @@ func (c *amConnection) getServerInfo() (info serverInfo, err error) {
 	request.URL.RawQuery = q.Encode()
 
 	request.Header.Add(acceptAPIVersion, serverInfoEndpointVersion)
-	request.Header.Add(httpContentType, string(applicationJSON))
+	request.Header.Add(httpContentType, string(ApplicationJSON))
 	response, err := c.Do(request)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return info, err
 	}
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return info, err
 	}
 	if response.StatusCode != http.StatusOK {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return info, fmt.Errorf("server info request failed")
 	}
 	if err = json.Unmarshal(responseBody, &info); err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return info, err
 	}
 	return info, err
@@ -250,7 +250,7 @@ func (c *amConnection) attributesURL() string {
 	return c.baseURL + "/json/things/*?realm=" + c.realm
 }
 
-func fieldsQuery(fields []string) string {
+func FieldsQuery(fields []string) string {
 	if len(fields) > 0 {
 		return "&_fields=" + strings.Join(fields, ",")
 	}
@@ -258,8 +258,8 @@ func fieldsQuery(fields []string) string {
 }
 
 // amInfo returns AM related information to the client
-func (c *amConnection) amInfo() (info amInfoSet, err error) {
-	return amInfoSet{
+func (c *amConnection) AMInfo() (info AMInfoResponse, err error) {
+	return AMInfoResponse{
 		Realm:          c.realm,
 		AccessTokenURL: c.accessTokenURL(),
 		AttributesURL:  c.attributesURL(),
@@ -268,43 +268,49 @@ func (c *amConnection) amInfo() (info amInfoSet, err error) {
 }
 
 // accessToken makes an access token request with the given session token and payload
-func (c *amConnection) accessToken(tokenID string, content contentType, payload string) ([]byte, error) {
+func (c *amConnection) AccessToken(tokenID string, content ContentType, payload string) ([]byte, error) {
 	request, err := http.NewRequest(http.MethodPost, c.accessTokenURL(), strings.NewReader(payload))
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, nil))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, nil))
 		return nil, err
 	}
 	return c.makeCommandRequest(tokenID, content, request)
 }
 
 // attributes makes a thing attributes request with the given session token and payload
-func (c *amConnection) attributes(tokenID string, content contentType, payload string, names []string) (reply []byte, err error) {
-	request, err := http.NewRequest(http.MethodGet, c.attributesURL()+fieldsQuery(names), strings.NewReader(payload))
+func (c *amConnection) Attributes(tokenID string, content ContentType, payload string, names []string) (reply []byte, err error) {
+	request, err := http.NewRequest(http.MethodGet, c.attributesURL()+FieldsQuery(names), strings.NewReader(payload))
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, nil))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, nil))
 		return nil, err
 	}
 	return c.makeCommandRequest(tokenID, content, request)
 }
 
-func (c *amConnection) makeCommandRequest(tokenID string, content contentType, request *http.Request) (reply []byte, err error) {
+func (c *amConnection) makeCommandRequest(tokenID string, content ContentType, request *http.Request) (reply []byte, err error) {
 	request.Header.Set(acceptAPIVersion, thingsEndpointVersion)
 	request.Header.Set(httpContentType, string(content))
 	request.AddCookie(&http.Cookie{Name: c.cookieName, Value: tokenID})
 	response, err := c.Do(request)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return nil, err
 	}
 	defer response.Body.Close()
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return nil, err
 	}
 	if response.StatusCode != http.StatusOK {
-		DebugLogger.Println(debug.DumpHTTPRoundTrip(request, response))
+		debug.Logger.Println(debug.DumpHTTPRoundTrip(request, response))
 		return responseBody, parseAMError(responseBody, response.StatusCode)
 	}
 	return responseBody, err
+}
+
+// SetAuthenticationTree changes the authentication tree that the connection was created with.
+// This is a convenience function for functional testing.
+func SetAuthenticationTree(connection Connection, tree string) {
+	connection.(*amConnection).authTree = tree
 }

--- a/internal/client/amconn_test.go
+++ b/internal/client/amconn_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package thing
+package client
 
 import (
 	"crypto/tls"
@@ -76,7 +76,7 @@ func testAMClientInitialise(mux *http.ServeMux) (err error) {
 	}
 	testSetRootCAs(c, server)
 
-	err = c.initialise()
+	err = c.Initialise()
 	if err != nil {
 		return err
 	}
@@ -144,12 +144,12 @@ func testAMClientAuthenticate(mux *http.ServeMux) (err error) {
 	}
 	testSetRootCAs(c, server)
 
-	err = c.initialise()
+	err = c.Initialise()
 	if err != nil {
 		return err
 	}
 
-	reply, err := c.authenticate(authenticatePayload{})
+	reply, err := c.Authenticate(AuthenticatePayload{})
 	if err != nil {
 		return err
 	}
@@ -160,8 +160,8 @@ func testAMClientAuthenticate(mux *http.ServeMux) (err error) {
 }
 
 func TestAMClient_Authenticate(t *testing.T) {
-	info := authenticatePayload{
-		sessionToken: sessionToken{TokenID: "12345"},
+	info := AuthenticatePayload{
+		SessionToken: SessionToken{TokenID: "12345"},
 	}
 	b, err := json.Marshal(info)
 	if err != nil {
@@ -197,7 +197,7 @@ func TestAMClient_AMInfo(t *testing.T) {
 		realm:    testRealm,
 		authTree: testTree,
 	}
-	info, err := client.amInfo()
+	info, err := client.AMInfo()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,12 +239,12 @@ func testAMClientAccessToken(mux *http.ServeMux) (err error) {
 	}
 	testSetRootCAs(c, server)
 
-	err = c.initialise()
+	err = c.Initialise()
 	if err != nil {
 		return err
 	}
 
-	_, err = c.accessToken("aToken", applicationJOSE, "aSignedWT")
+	_, err = c.AccessToken("aToken", ApplicationJOSE, "aSignedWT")
 	return err
 }
 
@@ -294,12 +294,12 @@ func testAMClientAttributes(mux *http.ServeMux) (err error) {
 	}
 	testSetRootCAs(c, server)
 
-	err = c.initialise()
+	err = c.Initialise()
 	if err != nil {
 		return err
 	}
 
-	_, err = c.attributes("aToken", applicationJOSE, "aSignedWT", []string{})
+	_, err = c.Attributes("aToken", ApplicationJOSE, "aSignedWT", []string{})
 	return err
 }
 

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+type ContentType string
+
+const (
+	ApplicationJSON ContentType = "application/json"
+	ApplicationJOSE ContentType = "application/jose"
+)
+
+var ErrUnauthorised = errors.New("unauthorised")
+
+// connection to the ForgeRock platform
+type Connection interface {
+	// initialise the client. Must be called before the Client is used by a Thing
+	Initialise() error
+
+	// authenticate sends an authenticate request to the ForgeRock platform
+	Authenticate(payload AuthenticatePayload) (reply AuthenticatePayload, err error)
+
+	// amInfo returns the information required to construct valid signed JWTs
+	AMInfo() (info AMInfoResponse, err error)
+
+	// validateSession sends a validate session request
+	ValidateSession(tokenID string) (ok bool, err error)
+
+	// logoutSession makes a request to logout the session
+	LogoutSession(tokenID string) (err error)
+
+	// accessToken makes an access token request with the given session token and payload
+	AccessToken(tokenID string, content ContentType, payload string) (reply []byte, err error)
+
+	// attributes makes a thing attributes request with the given session token and payload
+	Attributes(tokenID string, content ContentType, payload string, names []string) (reply []byte, err error)
+}
+
+type ConnectionBuilder struct {
+	url   *url.URL
+	realm string
+	tree  string
+	key   crypto.Signer
+}
+
+func NewConnection() *ConnectionBuilder {
+	return &ConnectionBuilder{}
+}
+
+func (b *ConnectionBuilder) ConnectTo(url *url.URL) *ConnectionBuilder {
+	b.url = url
+	return b
+}
+
+func (b *ConnectionBuilder) InRealm(realm string) *ConnectionBuilder {
+	b.realm = realm
+	return b
+}
+
+func (b *ConnectionBuilder) WithTree(tree string) *ConnectionBuilder {
+	b.tree = tree
+	return b
+}
+
+func (b *ConnectionBuilder) WithKey(key crypto.Signer) *ConnectionBuilder {
+	b.key = key
+	return b
+}
+
+func (b *ConnectionBuilder) Create() (Connection, error) {
+	var connection Connection
+	switch b.url.Scheme {
+	case "http", "https":
+		connection = &amConnection{baseURL: b.url.String(), realm: b.realm, authTree: b.tree}
+	case "coap", "coaps":
+		var err error
+		if b.key == nil {
+			b.key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		}
+		if err != nil {
+			return nil, err
+		}
+		connection = &gatewayConnection{address: b.url.Host, key: b.key}
+	default:
+		return nil, fmt.Errorf("unsupported scheme `%s`, must be one of http(s) or coap(s)", b.url.Scheme)
+	}
+	err := connection.Initialise()
+	return connection, err
+}

--- a/internal/client/payload.go
+++ b/internal/client/payload.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/ForgeRock/iot-edge/pkg/callback"
+)
+
+// AMInfoResponse contains the information required to construct valid signed JWTs
+type AMInfoResponse struct {
+	Realm          string
+	AccessTokenURL string
+	AttributesURL  string
+	ThingsVersion  string
+}
+
+// AuthenticatePayload represents the outbound and inbound data during an authentication request
+type AuthenticatePayload struct {
+	SessionToken
+	AuthId    string              `json:"authId,omitempty"`
+	AuthIDKey string              `json:"auth_id_digest,omitempty"`
+	Callbacks []callback.Callback `json:"callbacks,omitempty"`
+}
+
+type GetAccessTokenPayload struct {
+	Scope []string `json:"scope,omitempty"`
+}
+
+// SessionToken holds a session token
+type SessionToken struct {
+	TokenID string `json:"tokenId,omitempty"`
+}
+
+// ThingEndpointPayload wraps the payload destined for the Thing endpoint with the session token
+type ThingEndpointPayload struct {
+	Token   string `json:"token"`
+	Payload string `json:"payload,omitempty"`
+}
+
+func (p GetAccessTokenPayload) String() string {
+	return payloadToString(p)
+}
+
+// HasSessionToken returns true if the payload contains a session token
+// Indicates that the authentication workflow has completed successfully
+func (p AuthenticatePayload) HasSessionToken() bool {
+	return p.TokenID != ""
+}
+
+func (p AuthenticatePayload) String() string {
+	return payloadToString(p)
+}
+
+func payloadToString(p interface{}) string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return ""
+	}
+
+	var out bytes.Buffer
+	err = json.Indent(&out, b, "", "\t")
+	if err != nil {
+		return ""
+	}
+	return out.String()
+}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crypto
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/ForgeRock/iot-edge/internal/jws"
+	"math/big"
+)
+
+// PublicKeyCertificate returns a stripped down tls certificate containing the public key
+func PublicKeyCertificate(key crypto.Signer) (cert tls.Certificate, err error) {
+	if key == nil {
+		return cert, jws.ErrMissingSigner
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+	}
+
+	raw, err := x509.CreateCertificate(rand.Reader, &template, &template, key.Public(), key)
+	if err != nil {
+		return cert, err
+	}
+	return tls.Certificate{
+
+		Certificate: [][]byte{raw},
+		PrivateKey:  key,
+		Leaf:        &template,
+	}, nil
+}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -19,9 +19,15 @@ package debug
 import (
 	"fmt"
 	"github.com/go-ocf/go-coap"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httputil"
 )
+
+// All SDK debug information is written to this Logger. The logger is muted by default. To see the debug output assign
+// your own logger (or a new one) to this variable.
+var Logger = log.New(ioutil.Discard, "", 0)
 
 // DumpHTTPRoundTrip will dump the given HTTP request and response
 func DumpHTTPRoundTrip(req *http.Request, res *http.Response) (message string) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package session
+
+import (
+	"crypto"
+	"errors"
+	"github.com/ForgeRock/iot-edge/internal/client"
+	"github.com/ForgeRock/iot-edge/pkg/callback"
+	"github.com/ForgeRock/iot-edge/pkg/session"
+	"net/url"
+	"time"
+)
+
+type DefaultSession struct {
+	connection client.Connection
+	token      string
+	nonce      int
+	key        crypto.Signer
+}
+
+func (s *DefaultSession) Token() string {
+	return s.token
+}
+
+func (s *DefaultSession) HasRestrictedToken() bool {
+	return s.key != nil
+}
+
+func (s *DefaultSession) SigningKey() crypto.Signer {
+	return s.key
+}
+
+func (s *DefaultSession) Nonce() int {
+	return s.nonce
+}
+
+func (s *DefaultSession) IncrementNonce() {
+	s.nonce++
+}
+
+func (s *DefaultSession) Valid() (bool, error) {
+	return s.connection.ValidateSession(s.token)
+}
+
+func (s *DefaultSession) Logout() error {
+	return s.connection.LogoutSession(s.token)
+}
+
+type Builder struct {
+	url        *url.URL
+	realm      string
+	tree       string
+	timeout    time.Duration
+	connection client.Connection
+	handlers   []callback.Handler
+}
+
+func (b *Builder) AuthenticateWith(handlers ...callback.Handler) session.Builder {
+	b.handlers = handlers
+	return b
+}
+
+func (b *Builder) ConnectTo(url *url.URL) session.Builder {
+	b.url = url
+	return b
+}
+
+func (b *Builder) WithConnection(connection client.Connection) session.Builder {
+	b.connection = connection
+	return b
+}
+
+func (b *Builder) InRealm(realm string) session.Builder {
+	b.realm = realm
+	return b
+}
+
+func (b *Builder) WithTree(tree string) session.Builder {
+	b.tree = tree
+	return b
+}
+
+func (b *Builder) TimeoutRequestAfter(d time.Duration) session.Builder {
+	b.timeout = d
+	return b
+}
+
+func (b *Builder) Create() (session.Session, error) {
+	var err error
+	if b.connection == nil {
+		if b.url == nil {
+			return nil, errors.New("url must be provided")
+		}
+		b.connection, err = client.NewConnection().
+			ConnectTo(b.url).
+			InRealm(b.realm).
+			WithTree(b.tree).
+			Create()
+		if err != nil {
+			return nil, err
+		}
+	}
+	auth := client.AuthenticatePayload{}
+	var key crypto.Signer
+	for {
+		if auth, err = b.connection.Authenticate(auth); err != nil {
+			return nil, err
+		}
+
+		if auth.HasSessionToken() {
+			return &DefaultSession{
+				connection: b.connection,
+				token:      auth.TokenID,
+				key:        key,
+			}, nil
+		}
+		if key, err = callback.ProcessCallbacks(b.handlers, auth.Callbacks); err != nil {
+			return nil, err
+		}
+	}
+}

--- a/internal/thing/thing.go
+++ b/internal/thing/thing.go
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package thing
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/ForgeRock/iot-edge/internal/client"
+	"github.com/ForgeRock/iot-edge/internal/debug"
+	"github.com/ForgeRock/iot-edge/internal/jws"
+	isession "github.com/ForgeRock/iot-edge/internal/session"
+	"github.com/ForgeRock/iot-edge/pkg/callback"
+	"github.com/ForgeRock/iot-edge/pkg/session"
+	"github.com/ForgeRock/iot-edge/pkg/thing"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+	"net/url"
+	"time"
+)
+
+type DefaultThing struct {
+	connection client.Connection
+	handlers   []callback.Handler
+	session    session.Session
+}
+
+func (t *DefaultThing) Logout() error {
+	return t.session.Logout()
+}
+
+// makeAuthorisedRequest makes a request that requires a session token
+// if the session has expired, the session is renewed and the request is repeated
+func (t *DefaultThing) makeAuthorisedRequest(f func(session session.Session) error) (err error) {
+	for i := 0; i < 2; i++ {
+		err = f(t.session)
+		if err == nil || !errors.Is(err, client.ErrUnauthorised) {
+			return err
+		}
+		valid, validateErr := t.session.Valid()
+		if validateErr != nil || valid {
+			return err
+		}
+		builder := &isession.Builder{}
+		t.session, err = builder.
+			WithConnection(t.connection).
+			AuthenticateWith(t.handlers...).
+			Create()
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// signedRequestClaims defines the claims expected in the signed JWT provided with a signed request
+type signedRequestClaims struct {
+	CSRF string `json:"csrf"`
+}
+
+func signedJWTBody(session session.Session, url string, version string, body interface{}) (string, error) {
+	opts := &jose.SignerOptions{}
+	opts.WithHeader("aud", url)
+	opts.WithHeader("api", version)
+	opts.WithHeader("nonce", session.Nonce())
+	// increment the nonce so that the token can be used in a subsequent request
+	session.IncrementNonce()
+
+	sig, err := jws.NewSigner(session.SigningKey(), opts)
+	if err != nil {
+		return "", err
+	}
+	builder := jwt.Signed(sig).Claims(signedRequestClaims{CSRF: session.Token()})
+	if body != nil {
+		builder = builder.Claims(body)
+	}
+	return builder.CompactSerialize()
+}
+
+func (t *DefaultThing) RequestAccessToken(scopes ...string) (response thing.AccessTokenResponse, err error) {
+	payload := client.GetAccessTokenPayload{Scope: scopes}
+	var requestBody string
+	var content client.ContentType
+
+	err = t.makeAuthorisedRequest(func(session session.Session) error {
+		if session.HasRestrictedToken() {
+			info, err := t.connection.AMInfo()
+			if err != nil {
+				return err
+			}
+			requestBody, err = signedJWTBody(session, info.AccessTokenURL, info.ThingsVersion, payload)
+			if err != nil {
+				return err
+			}
+			content = client.ApplicationJOSE
+		} else {
+			b, err := json.Marshal(payload)
+			if err != nil {
+				return err
+			}
+			requestBody = string(b)
+			content = client.ApplicationJSON
+		}
+		reply, err := t.connection.AccessToken(session.Token(), content, requestBody)
+		if reply != nil {
+			debug.Logger.Println("RequestAccessToken response: ", string(reply))
+		}
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(reply, &response.Content)
+	})
+	return response, err
+}
+
+func (t *DefaultThing) RequestAttributes(names ...string) (response thing.AttributesResponse, err error) {
+	err = t.makeAuthorisedRequest(func(session session.Session) error {
+		var requestBody string
+		var content client.ContentType
+		if session.HasRestrictedToken() {
+			info, err := t.connection.AMInfo()
+			if err != nil {
+				return err
+			}
+			requestBody, err = signedJWTBody(session, info.AttributesURL+client.FieldsQuery(names), info.ThingsVersion, nil)
+			if err != nil {
+				return err
+			}
+			content = client.ApplicationJOSE
+		} else {
+			content = client.ApplicationJSON
+		}
+		reply, err := t.connection.Attributes(session.Token(), content, requestBody, names)
+		if err != nil {
+			debug.Logger.Println("RequestAttributes response: ", string(reply))
+			return err
+		}
+		return json.Unmarshal(reply, &response.Content)
+	})
+	return response, err
+}
+
+type authHandlerBuilder struct {
+	thingID string
+	keyID   string
+	key     crypto.Signer
+	claims  func() interface{}
+}
+
+type regHandlerBuilder struct {
+	certificates []*x509.Certificate
+	claims       func() interface{}
+}
+
+type BaseBuilder struct {
+	u           *url.URL
+	realm       string
+	tree        string
+	thingType   callback.ThingType
+	timeout     time.Duration
+	handlers    []callback.Handler
+	authHandler *authHandlerBuilder
+	regHandler  *regHandlerBuilder
+	connection  client.Connection
+}
+
+func (b *BaseBuilder) AsService() thing.Builder {
+	b.thingType = callback.TypeService
+	return b
+}
+
+func (b *BaseBuilder) AuthenticateThing(thingID string, keyID string, key crypto.Signer, claims func() interface{}) thing.Builder {
+	b.authHandler = &authHandlerBuilder{
+		thingID: thingID,
+		keyID:   keyID,
+		key:     key,
+		claims:  claims,
+	}
+	return b
+}
+
+func (b *BaseBuilder) RegisterThing(certificates []*x509.Certificate, claims func() interface{}) thing.Builder {
+	b.regHandler = &regHandlerBuilder{
+		certificates: certificates,
+		claims:       claims,
+	}
+	return b
+}
+
+func (b *BaseBuilder) ConnectTo(u *url.URL) thing.Builder {
+	b.u = u
+	return b
+}
+
+func (b *BaseBuilder) HandleCallbacksWith(handlers ...callback.Handler) thing.Builder {
+	b.handlers = handlers
+	return b
+}
+
+func (b *BaseBuilder) InRealm(realm string) thing.Builder {
+	b.realm = realm
+	return b
+}
+
+func (b *BaseBuilder) WithTree(tree string) thing.Builder {
+	b.tree = tree
+	return b
+}
+
+func (b *BaseBuilder) TimeoutRequestAfter(d time.Duration) thing.Builder {
+	b.timeout = d
+	return b
+}
+
+func (b *BaseBuilder) WithConnection(connection client.Connection) thing.Builder {
+	b.connection = connection
+	return b
+}
+
+func (b *BaseBuilder) Create() (thing.Thing, error) {
+	if b.connection == nil {
+		if b.u == nil {
+			return nil, errors.New("URL must be provided via ConnectTo")
+		}
+		var err error
+		b.connection, err = client.NewConnection().
+			ConnectTo(b.u).
+			InRealm(b.realm).
+			WithTree(b.tree).
+			Create()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if b.authHandler != nil {
+		// check we have a signer and key ID
+		if b.authHandler.key == nil {
+			return nil, fmt.Errorf("authenticate thing requires Key")
+		}
+		if b.authHandler.keyID == "" {
+			return nil, fmt.Errorf("authenticate thing requires Key ID")
+		}
+		// get AM info to obtain the realm from the gateway
+		info, err := b.connection.AMInfo()
+		if err != nil {
+			return nil, err
+		}
+		b.handlers = append(b.handlers, callback.AuthenticateHandler{
+			Realm:   info.Realm,
+			ThingID: b.authHandler.thingID,
+			KeyID:   b.authHandler.keyID,
+			Key:     b.authHandler.key,
+			Claims:  b.authHandler.claims,
+		})
+		if b.regHandler != nil {
+			if b.thingType == "" {
+				b.thingType = callback.TypeDevice
+			}
+			b.handlers = append(b.handlers, callback.RegisterHandler{
+				Realm:        info.Realm,
+				ThingID:      b.authHandler.thingID,
+				ThingType:    b.thingType,
+				KeyID:        b.authHandler.keyID,
+				Key:          b.authHandler.key,
+				Certificates: b.regHandler.certificates,
+				Claims:       b.regHandler.claims,
+			})
+		}
+	}
+	builder := &isession.Builder{}
+	thingSession, err := builder.
+		WithConnection(b.connection).
+		AuthenticateWith(b.handlers...).
+		Create()
+	thing := &DefaultThing{
+		connection: b.connection,
+		handlers:   b.handlers,
+		session:    thingSession,
+	}
+	return thing, err
+}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package builder
+
+import (
+	isession "github.com/ForgeRock/iot-edge/internal/session"
+	ithing "github.com/ForgeRock/iot-edge/internal/thing"
+	"github.com/ForgeRock/iot-edge/pkg/session"
+	"github.com/ForgeRock/iot-edge/pkg/thing"
+)
+
+// Thing returns a new Thing builder.
+func Thing() thing.Builder {
+	return &ithing.BaseBuilder{}
+}
+
+// Session returns a new Session builder.
+func Session() session.Builder {
+	return &isession.Builder{}
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package session
+
+import (
+	"crypto"
+	"github.com/ForgeRock/iot-edge/pkg/callback"
+	"net/url"
+	"time"
+)
+
+// Session holds session data
+type Session interface {
+
+	// Token returns the session token
+	Token() string
+
+	// HasRestrictedToken returns true if the session has a restricted token
+	HasRestrictedToken() bool
+
+	// SigningKey returns the signing key associated with a restricted SSO token
+	SigningKey() crypto.Signer
+
+	// Nonce returns the session nonce
+	Nonce() int
+
+	// IncrementNonce increments the session nonce
+	IncrementNonce()
+
+	// Valid returns true if the session is valid
+	Valid() (bool, error)
+
+	// Logout the session
+	Logout() error
+}
+
+type Builder interface {
+	ConnectTo(url *url.URL) Builder
+
+	InRealm(realm string) Builder
+
+	WithTree(tree string) Builder
+
+	AuthenticateWith(handlers ...callback.Handler) Builder
+
+	TimeoutRequestAfter(d time.Duration) Builder
+
+	Create() (Session, error)
+}

--- a/pkg/thing/payload.go
+++ b/pkg/thing/payload.go
@@ -17,60 +17,9 @@
 package thing
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ForgeRock/iot-edge/pkg/callback"
 )
-
-// amInfoSet contains the information required to construct valid signed JWTs
-type amInfoSet struct {
-	Realm          string
-	AccessTokenURL string
-	AttributesURL  string
-	ThingsVersion  string
-}
-
-// authenticatePayload represents the outbound and inbound data during an authentication request
-type authenticatePayload struct {
-	sessionToken
-	AuthId    string              `json:"authId,omitempty"`
-	AuthIDKey string              `json:"auth_id_digest,omitempty"`
-	Callbacks []callback.Callback `json:"callbacks,omitempty"`
-}
-
-// HasSessionToken returns true if the payload contains a session token
-// Indicates that the authentication workflow has completed successfully
-func (p authenticatePayload) HasSessionToken() bool {
-	return p.TokenID != ""
-}
-
-type getAccessTokenPayload struct {
-	Scope []string `json:"scope,omitempty"`
-}
-
-func (p authenticatePayload) String() string {
-	return payloadToString(p)
-}
-
-func (p getAccessTokenPayload) String() string {
-	return payloadToString(p)
-}
-
-func payloadToString(p interface{}) string {
-	b, err := json.Marshal(p)
-	if err != nil {
-		return ""
-	}
-
-	var out bytes.Buffer
-	err = json.Indent(&out, b, "", "\t")
-	if err != nil {
-		return ""
-	}
-	return out.String()
-}
 
 // AccessTokenResponse contains the response received from AM after a successful access token request
 type AccessTokenResponse struct {
@@ -136,9 +85,4 @@ func (a AttributesResponse) Get(key string) ([]string, error) {
 		valuesAsStrings[i] = v.(string)
 	}
 	return valuesAsStrings, nil
-}
-
-// sessionToken holds a session token
-type sessionToken struct {
-	TokenID string `json:"tokenId,omitempty"`
 }

--- a/pkg/thing/thing.go
+++ b/pkg/thing/thing.go
@@ -18,63 +18,30 @@ package thing
 
 import (
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"fmt"
+	"github.com/ForgeRock/iot-edge/internal/debug"
 	"github.com/ForgeRock/iot-edge/internal/jws"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"time"
 )
 
-// All SDK debug information is written to this Logger. The logger is muted by default. To see the debug output assign
-// your own logger (or a new one) to this variable.
-var DebugLogger = log.New(ioutil.Discard, "", 0)
+// DebugLogger is the destination of all SDK debug information. The logger is muted by default. Redirect the debug
+// output by assigning your own logger to this variable or setting the output writer, for example:
+//
+//    thing.DebugLogger().SetOutput(os.Stdout)
+func DebugLogger() *log.Logger {
+	return debug.Logger
+}
 
-var (
-	ErrNoConnection             = errors.New("no defined connection")
-	ErrBuilderUnsupportedScheme = errors.New("builder connecting with unsupported scheme")
-	ErrUnauthorised             = errors.New("unauthorised")
-)
-
-type contentType string
-
-const (
-	applicationJSON contentType = "application/json"
-	applicationJOSE contentType = "application/jose"
-)
-
-// connection to the ForgeRock platform
-type connection interface {
-	// initialise the client. Must be called before the Client is used by a Thing
-	initialise() error
-
-	// authenticate sends an authenticate request to the ForgeRock platform
-	authenticate(payload authenticatePayload) (reply authenticatePayload, err error)
-
-	// amInfo returns the information required to construct valid signed JWTs
-	amInfo() (info amInfoSet, err error)
-
-	// validateSession sends a validate session request
-	validateSession(tokenID string) (ok bool, err error)
-
-	// logoutSession makes a request to logout the session
-	logoutSession(tokenID string) (err error)
-
-	// accessToken makes an access token request with the given session token and payload
-	accessToken(tokenID string, content contentType, payload string) (reply []byte, err error)
-
-	// attributes makes a thing attributes request with the given session token and payload
-	attributes(tokenID string, content contentType, payload string, names []string) (reply []byte, err error)
+// SetDebugLogger will replace the default debug logger.
+func SetDebugLogger(logger *log.Logger) {
+	if logger != nil {
+		debug.Logger = logger
+	}
 }
 
 // Thing represents a device or a service with a digital identity in the ForgeRock Identity Platform.
@@ -89,216 +56,10 @@ type Thing interface {
 	// If no names are specified then all the allowed attributes will be returned.
 	RequestAttributes(names ...string) (response AttributesResponse, err error)
 
-	// Session returns the current session for the Thing.
-	Session() Session
-}
-
-// Session holds session data
-type Session interface {
-
-	// Token returns the session token
-	Token() string
-
-	// HasRestrictedToken returns true if the session has a restricted token
-	HasRestrictedToken() bool
-
-	// SigningKey returns the signing key associated with a restricted SSO token
-	SigningKey() crypto.Signer
-
-	// Nonce returns the session nonce
-	Nonce() int
-
-	// IncrementNonce increments the session nonce
-	IncrementNonce()
-
-	// Valid returns true if the session is valid
-	Valid() (bool, error)
-
-	// Reauthenticate the thing to create a new session
-	Reauthenticate() (session Session, err error)
-
-	// Logout the session
+	// Logout will invalidate the thing's session with AM. It is good practice to log out if the thing will not make
+	// new requests for a prolonged period. Once logged out the thing will automatically create a new session when a
+	// new request is made.
 	Logout() error
-}
-
-type defaultThing struct {
-	connection connection
-	handlers   []callback.Handler
-	session    Session
-}
-
-type defaultSession struct {
-	thing Thing
-	token string
-	nonce int
-	key   crypto.Signer
-}
-
-func (s *defaultSession) Token() string {
-	return s.token
-}
-
-func (s *defaultSession) HasRestrictedToken() bool {
-	return s.key != nil
-}
-
-func (s *defaultSession) SigningKey() crypto.Signer {
-	return s.key
-}
-
-func (s *defaultSession) Nonce() int {
-	return s.nonce
-}
-
-func (s *defaultSession) IncrementNonce() {
-	s.nonce++
-}
-
-func (s *defaultSession) Valid() (bool, error) {
-	if s.thing == nil || s.thing.(*defaultThing).connection == nil {
-		return false, ErrNoConnection
-	}
-	return s.thing.(*defaultThing).connection.validateSession(s.token)
-}
-
-func (s *defaultSession) Reauthenticate() (session Session, err error) {
-	err = s.thing.(*defaultThing).authenticate()
-	return s.thing.Session(), err
-}
-
-func (s *defaultSession) Logout() error {
-	return s.thing.(*defaultThing).connection.logoutSession(s.token)
-}
-
-// authenticate the Thing
-func (t *defaultThing) authenticate() (err error) {
-	auth := authenticatePayload{}
-	var key crypto.Signer
-	for {
-		if auth, err = t.connection.authenticate(auth); err != nil {
-			return err
-		}
-
-		if auth.HasSessionToken() {
-			t.session = &defaultSession{thing: t, token: auth.TokenID, key: key}
-			return nil
-		}
-		if key, err = processCallbacks(t.handlers, auth.Callbacks); err != nil {
-			return err
-		}
-	}
-}
-
-func (t *defaultThing) Session() Session {
-	return t.session
-}
-
-// makeAuthorisedRequest makes a request that requires a session token
-// if the session has expired, the session is renewed and the request is repeated
-func (t *defaultThing) makeAuthorisedRequest(f func(session Session) error) (err error) {
-	session := t.Session()
-	for i := 0; i < 2; i++ {
-		err = f(session)
-		if err == nil || !errors.Is(err, ErrUnauthorised) {
-			return err
-		}
-		valid, validateErr := t.connection.validateSession(t.session.Token())
-		if validateErr != nil || valid {
-			return err
-		}
-		session, err = session.Reauthenticate()
-		if err != nil {
-			return err
-		}
-	}
-	return err
-}
-
-// signedRequestClaims defines the claims expected in the signed JWT provided with a signed request
-type signedRequestClaims struct {
-	CSRF string `json:"csrf"`
-}
-
-func signedJWTBody(session Session, url string, version string, body interface{}) (string, error) {
-	opts := &jose.SignerOptions{}
-	opts.WithHeader("aud", url)
-	opts.WithHeader("api", version)
-	opts.WithHeader("nonce", session.Nonce())
-	// increment the nonce so that the token can be used in a subsequent request
-	session.IncrementNonce()
-
-	sig, err := jws.NewSigner(session.SigningKey(), opts)
-	if err != nil {
-		return "", err
-	}
-	builder := jwt.Signed(sig).Claims(signedRequestClaims{CSRF: session.Token()})
-	if body != nil {
-		builder = builder.Claims(body)
-	}
-	return builder.CompactSerialize()
-}
-
-func (t *defaultThing) RequestAccessToken(scopes ...string) (response AccessTokenResponse, err error) {
-	payload := getAccessTokenPayload{Scope: scopes}
-	var requestBody string
-	var content contentType
-
-	err = t.makeAuthorisedRequest(func(session Session) error {
-		if session.HasRestrictedToken() {
-			info, err := t.connection.amInfo()
-			if err != nil {
-				return err
-			}
-			requestBody, err = signedJWTBody(session, info.AccessTokenURL, info.ThingsVersion, payload)
-			if err != nil {
-				return err
-			}
-			content = applicationJOSE
-		} else {
-			b, err := json.Marshal(payload)
-			if err != nil {
-				return err
-			}
-			requestBody = string(b)
-			content = applicationJSON
-		}
-		reply, err := t.connection.accessToken(session.Token(), content, requestBody)
-		if reply != nil {
-			DebugLogger.Println("RequestAccessToken response: ", string(reply))
-		}
-		if err != nil {
-			return err
-		}
-		return json.Unmarshal(reply, &response.Content)
-	})
-	return response, err
-}
-
-func (t *defaultThing) RequestAttributes(names ...string) (response AttributesResponse, err error) {
-	err = t.makeAuthorisedRequest(func(session Session) error {
-		var requestBody string
-		var content contentType
-		if session.HasRestrictedToken() {
-			info, err := t.connection.amInfo()
-			if err != nil {
-				return err
-			}
-			requestBody, err = signedJWTBody(session, info.AttributesURL+fieldsQuery(names), info.ThingsVersion, nil)
-			if err != nil {
-				return err
-			}
-			content = applicationJOSE
-		} else {
-			content = applicationJSON
-		}
-		reply, err := t.connection.attributes(session.Token(), content, requestBody, names)
-		if err != nil {
-			DebugLogger.Println("RequestAttributes response: ", string(reply))
-			return err
-		}
-		return json.Unmarshal(reply, &response.Content)
-	})
-	return response, err
 }
 
 // Builder interface provides methods to setup and initialise a Thing
@@ -327,77 +88,6 @@ type Builder interface {
 	Create() (Thing, error)
 }
 
-type authHandlerBuilder struct {
-	thingID string
-	keyID   string
-	key     crypto.Signer
-	claims  func() interface{}
-}
-
-type regHandlerBuilder struct {
-	certificates []*x509.Certificate
-	claims       func() interface{}
-}
-
-type baseBuilder struct {
-	u           *url.URL
-	realm       string
-	tree        string
-	thingType   callback.ThingType
-	timeout     time.Duration
-	handlers    []callback.Handler
-	authHandler *authHandlerBuilder
-	regHandler  *regHandlerBuilder
-}
-
-func (b *baseBuilder) AsService() Builder {
-	b.thingType = callback.TypeService
-	return b
-}
-
-func (b *baseBuilder) AuthenticateThing(thingID string, keyID string, key crypto.Signer, claims func() interface{}) Builder {
-	b.authHandler = &authHandlerBuilder{
-		thingID: thingID,
-		keyID:   keyID,
-		key:     key,
-		claims:  claims,
-	}
-	return b
-}
-
-func (b *baseBuilder) RegisterThing(certificates []*x509.Certificate, claims func() interface{}) Builder {
-	b.regHandler = &regHandlerBuilder{
-		certificates: certificates,
-		claims:       claims,
-	}
-	return b
-}
-
-func (b *baseBuilder) ConnectTo(u *url.URL) Builder {
-	b.u = u
-	return b
-}
-
-func (b *baseBuilder) HandleCallbacksWith(handlers ...callback.Handler) Builder {
-	b.handlers = handlers
-	return b
-}
-
-func (b *baseBuilder) InRealm(realm string) Builder {
-	b.realm = realm
-	return b
-}
-
-func (b *baseBuilder) WithTree(tree string) Builder {
-	b.tree = tree
-	return b
-}
-
-func (b *baseBuilder) TimeoutRequestAfter(d time.Duration) Builder {
-	b.timeout = d
-	return b
-}
-
 // JWKThumbprint calculates the base64url-encoded JWK Thumbprint value for the given key.
 // The thumbprint can be used for identifying or selecting the key.
 // See https://tools.ietf.org/html/rfc7638
@@ -410,97 +100,4 @@ func JWKThumbprint(key crypto.Signer) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(thumbprint), nil
-}
-
-func (b *baseBuilder) Create() (Thing, error) {
-	if b.u == nil {
-		return nil, ErrNoConnection
-	}
-	var client connection
-	switch b.u.Scheme {
-	case "http", "https":
-		client = &amConnection{baseURL: b.u.String(), realm: b.realm, authTree: b.tree}
-	case "coap", "coaps":
-		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			return nil, err
-		}
-		client = &gatewayConnection{address: b.u.Host, key: key}
-	default:
-		return nil, ErrBuilderUnsupportedScheme
-	}
-	err := client.initialise()
-	if err != nil {
-		return nil, err
-	}
-	if b.authHandler != nil {
-		// check we have a signer and key ID
-		if b.authHandler.key == nil {
-			return nil, fmt.Errorf("authenticate thing requires Key")
-		}
-		if b.authHandler.keyID == "" {
-			return nil, fmt.Errorf("authenticate thing requires Key ID")
-		}
-		// get AM info to obtain the realm from the gateway
-		info, err := client.amInfo()
-		if err != nil {
-			return nil, err
-		}
-		b.handlers = append(b.handlers, callback.AuthenticateHandler{
-			Realm:   info.Realm,
-			ThingID: b.authHandler.thingID,
-			KeyID:   b.authHandler.keyID,
-			Key:     b.authHandler.key,
-			Claims:  b.authHandler.claims,
-		})
-		if b.regHandler != nil {
-			b.handlers = append(b.handlers, callback.RegisterHandler{
-				Realm:        info.Realm,
-				ThingID:      b.authHandler.thingID,
-				ThingType:    b.thingType,
-				KeyID:        b.authHandler.keyID,
-				Key:          b.authHandler.key,
-				Certificates: b.regHandler.certificates,
-				Claims:       b.regHandler.claims,
-			})
-		}
-	}
-	thing := &defaultThing{
-		connection: client,
-		handlers:   b.handlers,
-	}
-	err = thing.authenticate()
-	return thing, err
-}
-
-// New returns a new Thing builder
-func New() Builder {
-	return &baseBuilder{
-		thingType: callback.TypeDevice,
-	}
-}
-
-// processCallbacks attempts to respond to the callbacks with the given callback handlers
-func processCallbacks(handlers []callback.Handler, callbacks []callback.Callback) (key crypto.Signer, err error) {
-	for _, cb := range callbacks {
-	handlerLoop:
-		for _, h := range handlers {
-			switch err = h.Handle(cb); err {
-			case callback.ErrNotHandled:
-				continue
-			case nil:
-				if r, ok := h.(callback.ProofOfPossessionHandler); ok {
-					key = r.SigningKey()
-				}
-				break handlerLoop
-			default:
-				DebugLogger.Println(err)
-				continue
-			}
-		}
-		if err != nil {
-			return key, err
-		}
-	}
-	return key, nil
 }

--- a/tests/internal/anvil/framework.go
+++ b/tests/internal/anvil/framework.go
@@ -24,8 +24,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
+	"github.com/ForgeRock/iot-edge/internal/gateway"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
-	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil/am"
 	"github.com/dchest/uniuri"
 	"gopkg.in/square/go-jose.v2"
@@ -301,7 +301,7 @@ func CreateCertificate(caWebKey *jose.JSONWebKey, thingID string, thingKey crypt
 }
 
 // TestThingGateway creates a test Thing Gateway
-func TestThingGateway(realm string, authTree string) (*thing.ThingGateway, error) {
+func TestThingGateway(realm string, authTree string) (*gateway.ThingGateway, error) {
 	jwk, signer, err := ConfirmationKey(jose.ES256)
 	if err != nil {
 		return nil, err
@@ -316,7 +316,7 @@ func TestThingGateway(realm string, authTree string) (*thing.ThingGateway, error
 	if err != nil {
 		return nil, err
 	}
-	return thing.NewThingGateway(am.AMURL, realm, authTree, []callback.Handler{
+	return gateway.NewThingGateway(am.AMURL, realm, authTree, []callback.Handler{
 		callback.AuthenticateHandler{
 			Realm:   realm,
 			ThingID: attributes.Name,
@@ -368,12 +368,12 @@ func (a *AMTestState) Realm() string {
 
 // ThingGatewayTestState contains data and methods for testing the Thing Gateway client
 type ThingGatewayTestState struct {
-	ThingGateway *thing.ThingGateway
+	ThingGateway *gateway.ThingGateway
 	TestRealm    string
 }
 
 func (i *ThingGatewayTestState) SetGatewayTree(tree string) {
-	i.ThingGateway.AuthenticateWith(tree)
+	gateway.SetAuthenticationTree(i.ThingGateway, tree)
 }
 
 func (i *ThingGatewayTestState) URL() *url.URL {

--- a/tests/thingsdk/accesstoken.go
+++ b/tests/thingsdk/accesstoken.go
@@ -17,10 +17,10 @@
 package main
 
 import (
+	"github.com/ForgeRock/iot-edge/pkg/builder"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
-	"github.com/ForgeRock/iot-edge/tests/internal/anvil/am"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 	"reflect"
@@ -279,7 +279,7 @@ func (a AccessTokenWithExactScopesNonRestricted) Setup(state anvil.TestState) (d
 
 func (a AccessTokenWithExactScopesNonRestricted) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -311,7 +311,7 @@ func (a AccessTokenWithNoScopesNonRestricted) Setup(state anvil.TestState) (data
 
 func (a AccessTokenWithNoScopesNonRestricted) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -343,7 +343,7 @@ func (t *AccessTokenExpiredSession) Setup(state anvil.TestState) (data anvil.Thi
 
 func (t *AccessTokenExpiredSession) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -356,7 +356,7 @@ func (t *AccessTokenExpiredSession) Run(state anvil.TestState, data anvil.ThingD
 		return false
 	}
 
-	err = am.LogoutSession(thing.Session().Token())
+	err = thing.Logout()
 	if err != nil {
 		anvil.DebugLogger.Println("session logout failed", err)
 		return false

--- a/tests/thingsdk/attributes.go
+++ b/tests/thingsdk/attributes.go
@@ -17,10 +17,9 @@
 package main
 
 import (
+	"github.com/ForgeRock/iot-edge/pkg/builder"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
-	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
-	"github.com/ForgeRock/iot-edge/tests/internal/anvil/am"
 	"gopkg.in/square/go-jose.v2"
 )
 
@@ -127,7 +126,7 @@ func (t *AttributesWithNonRestrictedToken) Setup(state anvil.TestState) (data an
 
 func (t *AttributesWithNonRestrictedToken) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -174,7 +173,7 @@ func (t *AttributesExpiredSession) Setup(state anvil.TestState) (data anvil.Thin
 
 func (t *AttributesExpiredSession) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -187,7 +186,7 @@ func (t *AttributesExpiredSession) Run(state anvil.TestState, data anvil.ThingDa
 		return false
 	}
 
-	err = am.LogoutSession(thing.Session().Token())
+	err = thing.Logout()
 	if err != nil {
 		anvil.DebugLogger.Println("session logout failed", err)
 		return false

--- a/tests/thingsdk/authentication.go
+++ b/tests/thingsdk/authentication.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"github.com/ForgeRock/iot-edge/internal/client"
+	"github.com/ForgeRock/iot-edge/pkg/builder"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"github.com/ForgeRock/iot-edge/pkg/thing"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
@@ -25,7 +27,7 @@ import (
 
 func thingJWTAuth(state anvil.TestState, data anvil.ThingData) thing.Builder {
 	state.SetGatewayTree(jwtPopAuthTree)
-	return thing.New().
+	return builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopAuthTree).
@@ -104,7 +106,7 @@ func (t *AuthenticateWithoutConfirmationKey) Run(state anvil.TestState, data anv
 		return false
 	}
 	_, err = thingJWTAuth(state, data).Create()
-	if err != thing.ErrUnauthorised {
+	if err != client.ErrUnauthorised {
 		anvil.DebugLogger.Println(err)
 		return false
 	}
@@ -130,7 +132,7 @@ func (t *AuthenticateWithCustomClaims) Setup(state anvil.TestState) (data anvil.
 
 func (t *AuthenticateWithCustomClaims) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopAuthTreeCustomClaims)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopAuthTreeCustomClaims).
@@ -166,7 +168,7 @@ func (t *AuthenticateWithIncorrectCustomClaim) Setup(state anvil.TestState) (dat
 
 func (t *AuthenticateWithIncorrectCustomClaim) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopAuthTreeCustomClaims)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopAuthTreeCustomClaims).
@@ -176,7 +178,7 @@ func (t *AuthenticateWithIncorrectCustomClaim) Run(state anvil.TestState, data a
 			}{"0"}
 		})
 	_, err := builder.Create()
-	if err != thing.ErrUnauthorised {
+	if err != client.ErrUnauthorised {
 		anvil.DebugLogger.Println(err)
 		return false
 	}
@@ -195,7 +197,7 @@ func (a AuthenticateWithUserPwd) Setup(state anvil.TestState) (data anvil.ThingD
 
 func (a AuthenticateWithUserPwd) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -222,7 +224,7 @@ func (a AuthenticateWithIncorrectPwd) Setup(state anvil.TestState) (data anvil.T
 
 func (a AuthenticateWithIncorrectPwd) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(userPwdAuthTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(userPwdAuthTree).
@@ -230,7 +232,7 @@ func (a AuthenticateWithIncorrectPwd) Run(state anvil.TestState, data anvil.Thin
 			callback.NameHandler{Name: data.Id.Name},
 			callback.PasswordHandler{Password: "wrong"})
 	_, err := builder.Create()
-	if err != thing.ErrUnauthorised {
+	if err != client.ErrUnauthorised {
 		anvil.DebugLogger.Println(err)
 		return false
 	}
@@ -255,7 +257,7 @@ func (t *AuthenticateThingThroughGateway) Setup(state anvil.TestState) (data anv
 
 func (t *AuthenticateThingThroughGateway) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopAuthTree)
-	_, err := thing.New().
+	_, err := builder.Thing().
 		ConnectTo(state.URL()).
 		AuthenticateThing(data.Id.Name, data.Signer.KID, data.Signer.Signer, nil).
 		Create()

--- a/tests/thingsdk/main.go
+++ b/tests/thingsdk/main.go
@@ -21,7 +21,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
-	"github.com/ForgeRock/iot-edge/pkg/thing"
+	"github.com/ForgeRock/iot-edge/internal/debug"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil/am"
 	"gopkg.in/square/go-jose.v2"
@@ -87,7 +87,6 @@ var tests = []anvil.SDKTest{
 	&AttributesExpiredSession{},
 	&SessionValid{},
 	&SessionInvalid{},
-	&SessionReauthenticate{},
 	&SessionLogout{},
 }
 
@@ -99,7 +98,7 @@ func runAllTestsForContext(testCtx anvil.TestState) (result bool) {
 	result = true
 	var logfile *os.File
 	for _, test := range tests {
-		thing.DebugLogger, logfile = anvil.NewFileDebugger(subDir, anvil.TestName(test))
+		debug.Logger, logfile = anvil.NewFileDebugger(subDir, anvil.TestName(test))
 		if !anvil.RunTest(testCtx, test) {
 			result = false
 		}
@@ -158,7 +157,7 @@ func runTests() (err error) {
 		return err
 	}
 	thingsdkLogger, logfile := anvil.NewFileDebugger(debugDir, "thingsdk")
-	am.DebugLogger, thing.DebugLogger = thingsdkLogger, thingsdkLogger
+	am.DebugLogger, debug.Logger = thingsdkLogger, thingsdkLogger
 	defer func() {
 		_ = logfile.Close()
 	}()

--- a/tests/thingsdk/registration.go
+++ b/tests/thingsdk/registration.go
@@ -18,7 +18,8 @@ package main
 
 import (
 	"crypto/x509"
-	"github.com/ForgeRock/iot-edge/pkg/thing"
+	"github.com/ForgeRock/iot-edge/internal/client"
+	"github.com/ForgeRock/iot-edge/pkg/builder"
 	"github.com/ForgeRock/iot-edge/tests/internal/anvil"
 	"gopkg.in/square/go-jose.v2"
 	"strings"
@@ -53,7 +54,7 @@ func (t *RegisterDeviceCert) Setup(state anvil.TestState) (data anvil.ThingData,
 
 func (t *RegisterDeviceCert) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopRegCertTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopRegCertTree).
@@ -88,7 +89,7 @@ func (t *RegisterDeviceWithoutCert) Setup(state anvil.TestState) (data anvil.Thi
 
 func (t *RegisterDeviceWithoutCert) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopRegCertTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopRegCertTree).
@@ -96,7 +97,7 @@ func (t *RegisterDeviceWithoutCert) Run(state anvil.TestState, data anvil.ThingD
 		RegisterThing(nil, nil)
 
 	_, err := builder.Create()
-	if err != thing.ErrUnauthorised {
+	if err != client.ErrUnauthorised {
 		anvil.DebugLogger.Printf("Expected Not Authorised; got %v", err)
 		return false
 	}
@@ -138,7 +139,7 @@ func (t *RegisterDeviceWithAttributes) Run(state anvil.TestState, data anvil.Thi
 		EmployeeNumber []string `json:"employeeNumber"`
 	}{}
 	state.SetGatewayTree(jwtPopRegCertTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopRegCertTree).
@@ -190,7 +191,7 @@ func (t *RegisterServiceCert) Setup(state anvil.TestState) (data anvil.ThingData
 
 func (t *RegisterServiceCert) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopRegCertTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopRegCertTree).
@@ -245,7 +246,7 @@ func (t *RegisterDeviceNoKeyID) Setup(state anvil.TestState) (data anvil.ThingDa
 
 func (t *RegisterDeviceNoKeyID) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopRegCertTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopRegCertTree).
@@ -270,7 +271,7 @@ func (t *RegisterDeviceNoKey) Setup(state anvil.TestState) (data anvil.ThingData
 
 func (t *RegisterDeviceNoKey) Run(state anvil.TestState, data anvil.ThingData) bool {
 	state.SetGatewayTree(jwtPopRegCertTree)
-	builder := thing.New().
+	builder := builder.Thing().
 		ConnectTo(state.URL()).
 		InRealm(state.Realm()).
 		WithTree(jwtPopRegCertTree).


### PR DESCRIPTION
Summary of changes:
 - Removed circular dependency between thing and session
 - Added builders for Session and Connection
 - Moved Session and Connection to their own packages
 - Replaced Thing.Session() with Thing.Logout()
 - Moved various types and vars to common internal packages to accommodate the above changes
