### PR TITLE
IOTEDGE-981 Remove PoP functionality from public session API

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"math/big"
-	"strings"
 	"testing"
 )
 
@@ -82,24 +81,13 @@ func Test_processCallbacks(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			isPop, err := processCallbacks(test.handlers, callbacks)
+			signer, err := processCallbacks(test.handlers, callbacks)
 			if err != nil {
 				t.Errorf("processCallbacks() - unexpected error: %s", err)
 			}
-			if test.pop != isPop {
-				t.Errorf("processCallbacks() PoP restricted = %v, wanted %v", isPop, test.pop)
+			if test.pop && signer == nil {
+				t.Errorf("processCallbacks() should have returned a signing key")
 			}
 		})
-	}
-}
-
-func TestDefaultSession_RequestBody(t *testing.T) {
-	sesh := &DefaultSession{
-		key:           nil,
-		popRestricted: true,
-	}
-	_, _, err := sesh.RequestBody("", "", nil)
-	if err == nil || !strings.Contains(err.Error(), "no signing key was configured") {
-		t.Error("Expected RequestBody() to fail: err = ", err)
 	}
 }

--- a/internal/thing/thing.go
+++ b/internal/thing/thing.go
@@ -24,19 +24,21 @@ import (
 	"fmt"
 	"github.com/ForgeRock/iot-edge/internal/client"
 	"github.com/ForgeRock/iot-edge/internal/debug"
+	"github.com/ForgeRock/iot-edge/internal/jws"
 	isession "github.com/ForgeRock/iot-edge/internal/session"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"github.com/ForgeRock/iot-edge/pkg/session"
 	"github.com/ForgeRock/iot-edge/pkg/thing"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
 	"net/url"
 	"time"
 )
 
 type DefaultThing struct {
-	connection    client.Connection
-	handlers      []callback.Handler
-	session       session.Session
-	requestSigner crypto.Signer
+	connection client.Connection
+	handlers   []callback.Handler
+	session    session.Session
 }
 
 func (t *DefaultThing) Logout() error {
@@ -59,7 +61,6 @@ func (t *DefaultThing) makeAuthorisedRequest(f func(session session.Session) err
 		t.session, err = builder.
 			WithConnection(t.connection).
 			AuthenticateWith(t.handlers...).
-			SignRequestsWith(t.requestSigner).
 			Create()
 		if err != nil {
 			return err
@@ -68,19 +69,55 @@ func (t *DefaultThing) makeAuthorisedRequest(f func(session session.Session) err
 	return err
 }
 
+// signedRequestClaims defines the claims expected in the signed JWT provided with a signed request
+type signedRequestClaims struct {
+	CSRF string `json:"csrf"`
+}
+
+func signedJWTBody(session *isession.PoPSession, url string, version string, body interface{}) (string, error) {
+	opts := &jose.SignerOptions{}
+	opts.WithHeader("aud", url)
+	opts.WithHeader("api", version)
+	opts.WithHeader("nonce", session.Nonce())
+	// increment the nonce so that the token can be used in a subsequent request
+	session.IncrementNonce()
+
+	sig, err := jws.NewSigner(session.SigningKey(), opts)
+	if err != nil {
+		return "", err
+	}
+	builder := jwt.Signed(sig).Claims(signedRequestClaims{CSRF: session.Token()})
+	if body != nil {
+		builder = builder.Claims(body)
+	}
+	return builder.CompactSerialize()
+}
+
 func (t *DefaultThing) RequestAccessToken(scopes ...string) (response thing.AccessTokenResponse, err error) {
 	payload := client.GetAccessTokenPayload{Scope: scopes}
+	var requestBody string
+	var content client.ContentType
 
 	err = t.makeAuthorisedRequest(func(session session.Session) error {
-		info, err := t.connection.AMInfo()
-		if err != nil {
-			return err
+		if popSession, ok := session.(*isession.PoPSession); ok {
+			info, err := t.connection.AMInfo()
+			if err != nil {
+				return err
+			}
+			requestBody, err = signedJWTBody(popSession, info.AccessTokenURL, info.ThingsVersion, payload)
+			if err != nil {
+				return err
+			}
+			content = client.ApplicationJOSE
+		} else {
+			b, err := json.Marshal(payload)
+			if err != nil {
+				return err
+			}
+			requestBody = string(b)
+			content = client.ApplicationJSON
 		}
-		body, content, err := session.RequestBody(info.AccessTokenURL, info.ThingsVersion, payload)
-		if err != nil {
-			return err
-		}
-		reply, err := t.connection.AccessToken(session.Token(), client.ContentType(content), string(body))
+		reply, err := t.connection.AccessToken(session.Token(), content, requestBody)
 		if reply != nil {
 			debug.Logger.Println("RequestAccessToken response: ", string(reply))
 		}
@@ -94,15 +131,22 @@ func (t *DefaultThing) RequestAccessToken(scopes ...string) (response thing.Acce
 
 func (t *DefaultThing) RequestAttributes(names ...string) (response thing.AttributesResponse, err error) {
 	err = t.makeAuthorisedRequest(func(session session.Session) error {
-		info, err := t.connection.AMInfo()
-		if err != nil {
-			return err
+		var requestBody string
+		var content client.ContentType
+		if popSession, ok := session.(*isession.PoPSession); ok {
+			info, err := t.connection.AMInfo()
+			if err != nil {
+				return err
+			}
+			requestBody, err = signedJWTBody(popSession, info.AttributesURL+client.FieldsQuery(names), info.ThingsVersion, nil)
+			if err != nil {
+				return err
+			}
+			content = client.ApplicationJOSE
+		} else {
+			content = client.ApplicationJSON
 		}
-		body, content, err := session.RequestBody(info.AttributesURL+client.FieldsQuery(names), info.ThingsVersion, nil)
-		if err != nil {
-			return err
-		}
-		reply, err := t.connection.Attributes(session.Token(), client.ContentType(content), string(body), names)
+		reply, err := t.connection.Attributes(session.Token(), content, requestBody, names)
 		if err != nil {
 			debug.Logger.Println("RequestAttributes response: ", string(reply))
 			return err
@@ -205,7 +249,6 @@ func (b *BaseBuilder) Create() (thing.Thing, error) {
 			return nil, err
 		}
 	}
-	var requestSigner crypto.Signer
 	if b.authHandler != nil {
 		// check we have a signer and key ID
 		if b.authHandler.key == nil {
@@ -214,7 +257,6 @@ func (b *BaseBuilder) Create() (thing.Thing, error) {
 		if b.authHandler.keyID == "" {
 			return nil, fmt.Errorf("authenticate thing requires Key ID")
 		}
-		requestSigner = b.authHandler.key
 		// get AM info to obtain the realm from the gateway
 		info, err := b.connection.AMInfo()
 		if err != nil {
@@ -246,13 +288,13 @@ func (b *BaseBuilder) Create() (thing.Thing, error) {
 	thingSession, err := builder.
 		WithConnection(b.connection).
 		AuthenticateWith(b.handlers...).
-		SignRequestsWith(requestSigner).
 		Create()
-	thing := &DefaultThing{
-		connection:    b.connection,
-		handlers:      b.handlers,
-		session:       thingSession,
-		requestSigner: requestSigner,
+	if err != nil {
+		return nil, err
 	}
-	return thing, err
+	return &DefaultThing{
+		connection: b.connection,
+		handlers:   b.handlers,
+		session:    thingSession,
+	}, nil
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -17,7 +17,6 @@
 package session
 
 import (
-	"crypto"
 	"github.com/ForgeRock/iot-edge/pkg/callback"
 	"net/url"
 	"time"
@@ -34,11 +33,6 @@ type Session interface {
 
 	// Logout the session.
 	Logout() error
-
-	// RequestBody prepares the request payload based on the information available about the session. For example, if
-	// the session has a Proof of Possession restriction then this method will prepare a signed JWT containing the
-	// provided request properties.
-	RequestBody(url, version string, payload interface{}) (body []byte, contentType string, err error)
 }
 
 type Builder interface {
@@ -61,10 +55,6 @@ type Builder interface {
 
 	// TimeoutRequestAfter sets the timeout on the communications between the Thing and AM or the Thing Gateway.
 	TimeoutRequestAfter(d time.Duration) Builder
-
-	// SignRequestsWith the provided signer. This signer is used when session.RequestBody() is used to prepare the
-	// request that will be accompanied by this session token.
-	SignRequestsWith(signer crypto.Signer) Builder
 
 	// Create a Session instance and make an authentication request to AM. The callback handlers provided
 	// will be used to satisfy the callbacks received from the AM authentication process.


### PR DESCRIPTION
This mostly reverts yesterday's commit. The result is that the public session API does not expose anything about the PoP restriction.

I think we can add a helper function for processing the request body at a later stage instead.