### PR TITLE
IOTEDGE-1005 add building the gateway readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories
 vendor/
+
+# Binary directory
+bin/

--- a/README.md
+++ b/README.md
@@ -16,4 +16,7 @@ ForgeRock Identity Platform and can authenticate itself in order to interact wit
 See the [getting started guide](docs/getting-started.md) for information about how to use the SDK.
 
 ## Thing Gateway
-[Work in progress]
+The _Thing Gateway_ is an application that enables more constrained devices to interact with the ForgeRock Identity
+Platform by acting as a proxy between a _thing_ and the Platform.
+
+See the [build the Gateway guide](docs/building-the-gateway.md) for information about building the Gateway.

--- a/docs/building-the-gateway.md
+++ b/docs/building-the-gateway.md
@@ -1,0 +1,43 @@
+# Building the Gateway
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/engine/install/)
+- [Go](https://golang.org/doc/install)
+
+## Get the Gateway code
+
+Clone this repository
+
+```bash
+git clone git@github.com:ForgeRock/iot-edge.git
+```
+
+and change directory to the repository root:
+
+```bash
+cd iot-edge
+```
+
+## Building on the target system
+
+Build the Gateway into a binary:
+
+```bash
+go build -o ./bin/gateway ./cmd/gateway
+```
+
+Use the help flag to see the available command line options for the Gateway:
+
+```bash
+./bin/gateway -h
+```
+
+## Building in Docker
+
+Alternatively, the Golang docker container can be used to build the Gateway for `linux/amd64`:
+
+```bash
+docker pull golang:1.13
+docker run --rm -it -v "$PWD":/go/src/iot-edge -w /go/src/iot-edge golang:1.13 go build -o ./bin/gateway ./cmd/gateway
+```


### PR DESCRIPTION
I have left out mentioning cross-compiling at the moment since cgo makes it a little complicated (it is used by the `net` package). I thought we could add build instructions for cross-compiling using the Docker container as and when we can test the binary on the target device. I plan to do this for `linux/arm8` next.