### PR TITLE
Add SDK build tags

### DIFF
--- a/internal/client/amconn.go
+++ b/internal/client/amconn.go
@@ -1,3 +1,5 @@
+// +build !coap,!http http
+
 /*
  * Copyright 2020 ForgeRock AS
  *
@@ -39,15 +41,6 @@ const (
 	authIndexTypeQueryKey = "authIndexType"
 	authTreeQueryKey      = "authIndexValue"
 )
-
-// amConnection contains information for connecting directly to AM
-type amConnection struct {
-	http.Client
-	baseURL    string
-	realm      string
-	authTree   string
-	cookieName string
-}
 
 // newSessionRequest returns a new session request
 func (c *amConnection) newSessionRequest(tokenID string, action string) (request *http.Request, err error) {
@@ -248,13 +241,6 @@ func (c *amConnection) accessTokenURL() string {
 
 func (c *amConnection) attributesURL() string {
 	return c.baseURL + "/json/things/*?realm=" + c.realm
-}
-
-func FieldsQuery(fields []string) string {
-	if len(fields) > 0 {
-		return "&_fields=" + strings.Join(fields, ",")
-	}
-	return ""
 }
 
 // amInfo returns AM related information to the client

--- a/internal/client/amconn_noop.go
+++ b/internal/client/amconn_noop.go
@@ -1,0 +1,51 @@
+// +build coap,!http
+
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import "errors"
+
+var errHTTPNotBuilt = errors.New("http(s) scheme is unsupported")
+
+func (c amConnection) Initialise() error {
+	return errHTTPNotBuilt
+}
+
+func (c amConnection) Authenticate(payload AuthenticatePayload) (reply AuthenticatePayload, err error) {
+	return reply, errHTTPNotBuilt
+}
+
+func (c amConnection) AMInfo() (info AMInfoResponse, err error) {
+	return info, errHTTPNotBuilt
+}
+
+func (c amConnection) ValidateSession(tokenID string) (ok bool, err error) {
+	return ok, errHTTPNotBuilt
+}
+
+func (c amConnection) LogoutSession(tokenID string) (err error) {
+	return errHTTPNotBuilt
+}
+
+func (c amConnection) AccessToken(tokenID string, content ContentType, payload string) (reply []byte, err error) {
+	return reply, errHTTPNotBuilt
+}
+
+func (c amConnection) Attributes(tokenID string, content ContentType, payload string, names []string) (reply []byte, err error) {
+	return reply, errHTTPNotBuilt
+}

--- a/internal/client/connection.go
+++ b/internal/client/connection.go
@@ -23,8 +23,10 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/go-ocf/go-coap"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -96,6 +98,31 @@ func (b *ConnectionBuilder) WithKey(key crypto.Signer) *ConnectionBuilder {
 func (b *ConnectionBuilder) TimeoutRequestAfter(timeout time.Duration) *ConnectionBuilder {
 	b.timeout = timeout
 	return b
+}
+
+func FieldsQuery(fields []string) string {
+	if len(fields) > 0 {
+		return "&_fields=" + strings.Join(fields, ",")
+	}
+	return ""
+}
+
+// amConnection contains information for connecting directly to AM
+type amConnection struct {
+	http.Client
+	baseURL    string
+	realm      string
+	authTree   string
+	cookieName string
+}
+
+// gatewayConnection contains information for connecting to the Thing Gateway via COAP
+type gatewayConnection struct {
+	address string
+	timeout time.Duration
+	key     crypto.Signer
+	client  *coap.Client
+	conn    *coap.ClientConn
 }
 
 func (b *ConnectionBuilder) Create() (Connection, error) {

--- a/internal/client/gatewayconn.go
+++ b/internal/client/gatewayconn.go
@@ -1,3 +1,5 @@
+// +build coap !coap,!http
+
 /*
  * Copyright 2020 ForgeRock AS
  *
@@ -19,7 +21,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -46,15 +47,6 @@ func (e errCoAPStatusCode) Error() string {
 		msg += fmt.Sprintf(", payload: %s", string(e.payload))
 	}
 	return msg
-}
-
-// gatewayConnection contains information for connecting to the Thing Gateway via COAP
-type gatewayConnection struct {
-	address string
-	timeout time.Duration
-	key     crypto.Signer
-	client  *coap.Client
-	conn    *coap.ClientConn
 }
 
 // dial returns an existing connection or creates a new one

--- a/internal/client/gatewayconn_noop.go
+++ b/internal/client/gatewayconn_noop.go
@@ -1,0 +1,51 @@
+// +build http,!coap
+
+/*
+ * Copyright 2020 ForgeRock AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import "errors"
+
+var errCOAPNotBuilt = errors.New("coap(s) scheme is unsupported")
+
+func (c *gatewayConnection) Initialise() error {
+	return errCOAPNotBuilt
+}
+
+func (c *gatewayConnection) Authenticate(payload AuthenticatePayload) (reply AuthenticatePayload, err error) {
+	return reply, errCOAPNotBuilt
+}
+
+func (c *gatewayConnection) AMInfo() (info AMInfoResponse, err error) {
+	return info, errCOAPNotBuilt
+}
+
+func (c *gatewayConnection) ValidateSession(tokenID string) (ok bool, err error) {
+	return ok, errCOAPNotBuilt
+}
+
+func (c *gatewayConnection) LogoutSession(tokenID string) (err error) {
+	return errCOAPNotBuilt
+}
+
+func (c *gatewayConnection) AccessToken(tokenID string, content ContentType, payload string) (reply []byte, err error) {
+	return reply, errCOAPNotBuilt
+}
+
+func (c *gatewayConnection) Attributes(tokenID string, content ContentType, payload string, names []string) (reply []byte, err error) {
+	return reply, errCOAPNotBuilt
+}

--- a/tests/thingsdk/main.go
+++ b/tests/thingsdk/main.go
@@ -79,6 +79,8 @@ var tests = []anvil.SDKTest{
 	&AccessTokenWithNoScopesNonRestricted{},
 	&AccessTokenExpiredSession{},
 	&SimpleThingExample{},
+	&SimpleThingExampleTags{limitedTags: false},
+	&SimpleThingExampleTags{limitedTags: true},
 	&CertRegistrationExample{},
 	&GatewayAppAuth{},
 	&GatewayAppAuthNonDefaultKID{},


### PR DESCRIPTION
Use build tags to optionally leave either the HTTP or CoAP client out of the build process. 

Build both clients by either giving no client tags or providing both:
```
go run "thing/simple" .....
go run -tags http coap "thing/simple" .....
```
Build HTTP only:
```
go run -tags http "thing/simple" .....
```
Build CoAP only:
```
go run -tags coap "thing/simple" .....
```
Building a single client did reduce the size of the executable but not as much as expected. E.g. for simple thing:

Both = 7.8MB
CoAP = 7.6MB
HTTP = 6.9MB