### PR TITLE
IOTEDGE-1067 avoid using pointers in Mosquitto plugin cache

### DIFF
--- a/examples/proof-of-concept/mosquitto/mosquitto/Dockerfile
+++ b/examples/proof-of-concept/mosquitto/mosquitto/Dockerfile
@@ -25,7 +25,8 @@ RUN mkdir -p config plugin log
 
 # build OAuth2 auth plugin
 ADD oauth2-auth-plugin plugin
-ENV CGO_CFLAGS="-I/usr/local/include"
+ENV CGO_CFLAGS="-I/usr/local/include -fPIC"
+ENV CGO_LDFLAGS="-L/usr/local/lib -lmosquitto -shared"
 ENV CGO_ENABLED=1
 RUN cd ./plugin && go build -o oauth2-auth-plugin.so -buildmode=c-shared .
 


### PR DESCRIPTION
I was using the client pointer as a key in a map. These pointers belong in the "C" world and I think that the Go runtime is modifying them somehow while it is managing the map. The "Go" world can't change the "C" world hence causing the random plugin crashes.  