### PR TITLE
Remove examples versioning

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,4 +1,4 @@
-module github.com/ForgeRock/iot-edge/v7/examples
+module github.com/ForgeRock/iot-edge/examples
 
 go 1.15
 

--- a/examples/thing/cert-registration/main.go
+++ b/examples/thing/cert-registration/main.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/ForgeRock/iot-edge/v7/examples/secrets"
+	"github.com/ForgeRock/iot-edge/examples/secrets"
 	"github.com/ForgeRock/iot-edge/v7/pkg/builder"
 	"github.com/ForgeRock/iot-edge/v7/pkg/thing"
 )

--- a/examples/thing/simple/main.go
+++ b/examples/thing/simple/main.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/ForgeRock/iot-edge/v7/examples/secrets"
+	"github.com/ForgeRock/iot-edge/examples/secrets"
 	"github.com/ForgeRock/iot-edge/v7/pkg/builder"
 	"github.com/ForgeRock/iot-edge/v7/pkg/thing"
 )

--- a/examples/thing/user-token/main.go
+++ b/examples/thing/user-token/main.go
@@ -27,7 +27,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/ForgeRock/iot-edge/v7/examples/secrets"
+	"github.com/ForgeRock/iot-edge/examples/secrets"
 	"github.com/ForgeRock/iot-edge/v7/pkg/builder"
 	"github.com/ForgeRock/iot-edge/v7/pkg/thing"
 )

--- a/tests/iotsdk/examples.go
+++ b/tests/iotsdk/examples.go
@@ -119,7 +119,7 @@ func (t *SimpleThingExample) Run(state anvil.TestState, data anvil.ThingData) bo
 	ctx, cancel := testContext()
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ForgeRock/iot-edge/v7/examples/thing/simple",
+	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ForgeRock/iot-edge/examples/thing/simple",
 		"-url", state.URL().String(),
 		"-realm", state.TestRealm(),
 		"-audience", state.Audience(),
@@ -187,7 +187,7 @@ func (t *SimpleThingExampleTags) Run(state anvil.TestState, data anvil.ThingData
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "run", "-tags", tags,
-		"github.com/ForgeRock/iot-edge/v7/examples/thing/simple",
+		"github.com/ForgeRock/iot-edge/examples/thing/simple",
 		"-url", state.URL().String(),
 		"-realm", state.TestRealm(),
 		"-audience", state.Audience(),
@@ -264,7 +264,7 @@ func (t *CertRegistrationExample) Run(state anvil.TestState, data anvil.ThingDat
 	ctx, cancel := testContext()
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ForgeRock/iot-edge/v7/examples/thing/cert-registration",
+	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ForgeRock/iot-edge/examples/thing/cert-registration",
 		"-url", state.URL().String(),
 		"-realm", state.TestRealm(),
 		"-audience", state.Audience(),
@@ -339,7 +339,7 @@ func (t *DeviceTokenExample) Run(state anvil.TestState, data anvil.ThingData) bo
 	ctx, cancel := testContext()
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ForgeRock/iot-edge/v7/examples/thing/user-token",
+	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ForgeRock/iot-edge/examples/thing/user-token",
 		"-url", state.URL().String(),
 		"-realm", state.TestRealm(),
 		"-audience", state.Audience(),


### PR DESCRIPTION
This will allow us to use example packages alongside the versioned SDK in demos.

For example, in your demo mod you can get both like this:
```
require (
	github.com/ForgeRock/iot-edge/examples v0.0.0-20210127122824-1db14cae7bc4
	github.com/ForgeRock/iot-edge/v7 v7.0.1-0.20210120182133-45f829d086da
)
```